### PR TITLE
Fix frozen version

### DIFF
--- a/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
@@ -105,7 +105,7 @@ module ChefZero
         return versions if !constraint
         constraint = Gem::Requirement.new(constraint)
         new_versions = versions[cookbook_name]
-        new_versions = new_versions.select { |version| constraint.satisfied_by?(Gem::Version.new(version)) }
+        new_versions = new_versions.select { |version| constraint.satisfied_by?(Gem::Version.new(version.dup)) }
         result = versions.clone
         result[cookbook_name] = new_versions
         result


### PR DESCRIPTION
For some reason, the version is frozen, and Gem::Version is calling `.strip!` on it.
