### PR TITLE
fix undefined method .list on CookbookData

### DIFF
--- a/lib/chef_zero/cookbook_data.rb
+++ b/lib/chef_zero/cookbook_data.rb
@@ -162,7 +162,7 @@ module ChefZero
       end
     end
 
-    def self.list_directory(directory)
+    def self.list(directory)
       if directory.is_a?(Hash)
         directory.keys
       else


### PR DESCRIPTION
This function is referenced in `CookbookData.load_files` but it is referenced by the name `.list`. Changed from `.list_directory` to `.list`.

This will block you from being able to upload cookbooks into a Chef server
