### PR TITLE
Fix usage info to be consistent with latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Usage: chef-zero [ARGS]
     -H, --host HOST                  Host to bind to (default: 127.0.0.1)
     -p, --port PORT                  Port to listen on
         --[no-]generate-keys         Whether to generate actual keys or fake it (faster).  Default: false.
-    -d, --debug                      Show requests and debugging output
+    -l, --log-level LEVEL            Set the output log level
     -h, --help                       Show this message
         --version                    Show version
 ```


### PR DESCRIPTION
It is now -l/--log-level instead of --debug
