### PR TITLE
Use thin on Windows, puma everywhere else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
-rvm:
-  - 1.8.7
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - jruby-19mode
-
 script: bundle exec rake spec
 
 matrix:
   include:
+    - rvm: 1.8.7
+      env: SKIP_PEDANT=true
+    - rvm: 1.9.3
     - rvm: 1.9.3
       gemfile: gemfiles/gemfile.latest-pedant
+    - rvm: 1.9.3
+      env: SERVER=thin
+    - rvm: jruby-19mode
+      env: SKIP_PEDANT=true
+    - rvm: 2.0.0
+    - rvm: 2.0.0
+      env: SERVER=thin
   allow_failures:
-    - rvm: 1.8.7           # We support 1.8.7, but chef-pedant doesn't
-    - rvm: 2.0.0           # chef-pedant has at least one failure in 2.0.0
-    - rvm: jruby-19mode    # Mixlib Shellout uses fork+exec
+    - rvm: jruby-19mode
     - gemfile: gemfiles/gemfile.latest-pedant

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,5 @@ require 'bundler/gem_tasks'
 require 'chef_zero/version'
 
 task :spec do
-  sh 'ruby spec/run.rb'
+  require File.expand_path('spec/run')
 end

--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -1,5 +1,6 @@
 $:.unshift(File.dirname(__FILE__) + '/lib')
 require 'chef_zero/version'
+require 'rbconfig'
 
 Gem::Specification.new do |s|
   s.name = 'chef-zero'
@@ -11,7 +12,14 @@ Gem::Specification.new do |s|
   s.email = 'jkeiser@opscode.com'
   s.homepage = 'http://www.opscode.com'
 
-  s.add_dependency 'puma',          '~> 2.0'
+  if ENV['SERVER'] == 'thin' || RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+    # Windows and/or explicit thin testing
+    s.add_dependency 'thin', '~> 1.5'
+  else
+    # Everyone else
+    s.add_dependency 'puma', '~> 2.0'
+  end
+
   s.add_dependency 'mixlib-log',    '~> 1.3'
   s.add_dependency 'hashie',        '~> 2.0'
   s.add_dependency 'moneta',        '< 0.7.0' # For chef, see CHEF-3721

--- a/spec/run.rb
+++ b/spec/run.rb
@@ -5,21 +5,25 @@ require 'bundler/setup'
 require 'chef_zero/server'
 require 'rspec/core'
 
-require 'pedant'
-require 'pedant/opensource'
-
 server = ChefZero::Server.new(:port => 8889)
 server.start_background
 
-Pedant.config.suite = 'api'
-Pedant.config[:config_file] = 'spec/support/pedant.rb'
-Pedant.setup([
-  '--skip-validation',
-  '--skip-authentication',
-  '--skip-authorization'
-])
+unless ENV['SKIP_PEDANT']
+  require 'pedant'
+  require 'pedant/opensource'
 
-result = RSpec::Core::Runner.run(Pedant.config.rspec_args)
+  Pedant.config.suite = 'api'
+  Pedant.config[:config_file] = 'spec/support/pedant.rb'
+  Pedant.setup([
+    '--skip-validation',
+    '--skip-authentication',
+    '--skip-authorization'
+  ])
+
+  result = RSpec::Core::Runner.run(Pedant.config.rspec_args)
+else
+  result = 0
+end
 
 server.stop
 exit(result)


### PR DESCRIPTION
This also fixes the travis build matrix to allow us to "run" the tests that are broken in Pedant. A simple test like "can the server start and stop" is better than not testing at all :smile:
