### PR TITLE
fixup end_range typos

### DIFF
--- a/lib/chef_zero/solr/solr_parser.rb
+++ b/lib/chef_zero/solr/solr_parser.rb
@@ -142,7 +142,7 @@ module ChefZero
           right = next_token
           parse_error(right, "Expected left term in range query") if !right
           end_range = next_token
-          parse_error(right, "Expected end range '#{expected_end_range}") if !['{', '['].include?(end_range)
+          parse_error(right, "Expected end range '#{end_range}") if !['}', ']'].include?(end_range)
           Query::RangeQuery.new(left, right, token == '[', end_range == ']')
 
         elsif token == '('


### PR DESCRIPTION
Hi there.  I found what I thought might be a couple of typos when CZ tries to parse some of my chef searches.

The braces look like they are facing the wrong way for "normal" range queries, and then when it tried to throw the error there was a missing "expected_end_range" variable.  I think this is what was intended.
