### PR TITLE
improve depsolver error message

### DIFF
--- a/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
@@ -37,8 +37,11 @@ module ChefZero
         solved = depsolve(request, desired_versions.keys, desired_versions, environment_constraints)
         if !solved
           if @last_missing_dep && !cookbook_names.include?(@last_missing_dep)
-            return raise RestErrorResponse.new(412, "No such cookbook: #{@last_missing_dep}") 
+            return raise RestErrorResponse.new(412, "No such cookbook: #{@last_missing_dep}")
+          elsif @last_constraint_failure
+            return raise RestErrorResponse.new(412, "Could not satisfy version constraints for: #{@last_constraint_failure}")
           else
+
             return raise RestErrorResponse.new(412, "Unsolvable versions!")
           end
         end
@@ -52,7 +55,12 @@ module ChefZero
       end
 
       def depsolve(request, unsolved, desired_versions, environment_constraints)
-        return nil if desired_versions.values.any? { |versions| versions.empty? }
+        desired_versions.each do |cb, ver|
+          if ver.empty?
+            @last_constraint_failure = cb
+            return nil
+          end
+        end
 
         # If everything is already
         solve_for = unsolved[0]


### PR DESCRIPTION
- at least return the last cookbook that failed inside the recursive
  bowels of the depsolver.  not sure if this will produce a slightly
  misleading error messge in the case of a cookbook resolution failure,
  but it should give at least point at a cookbook that has a problem.
