### PR TITLE
Fix IPV6 support

### DIFF
--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -70,7 +70,6 @@ module ChefZero
 
     def initialize(options = {})
       @options = DEFAULT_OPTIONS.merge(options)
-      @options[:host] = "[#{@options[:host]}]" if @options[:host].include?(':')
       @options.freeze
 
       ChefZero::Log.level = @options[:log_level].to_sym
@@ -85,12 +84,19 @@ module ChefZero
     include ChefZero::Endpoints
 
     #
-    # The URL for this Chef Zero server.
+    # The URL for this Chef Zero server. If the given host is an IPV6 address,
+    # it is escaped in brackets according to RFC-2732.
+    #
+    # @see http://www.ietf.org/rfc/rfc2732.txt RFC-2732
     #
     # @return [String]
     #
     def url
-      "http://#{@options[:host]}:#{@options[:port]}"
+      @url ||= if @options[:host].include?(':')
+                 "http://[#{@options[:host]}]:#{@options[:port]}"
+               else
+                 "http://#{@options[:host]}:#{@options[:port]}"
+               end
     end
 
     #


### PR DESCRIPTION
In c3373e4, @danielsdeleo added support for IPV6, but I didn't understand the purpose of the bracket notation. I thought they were part of the `host`, but they are actually part of the URL. We _need_ the brackets in the URL, but we _cannot_ have the brackets in the host.
