### PR TITLE
Fixes #53: Errno::ENAMETOOLONG on metadata.json

### DIFF
--- a/lib/chef_zero/cookbook_data.rb
+++ b/lib/chef_zero/cookbook_data.rb
@@ -39,7 +39,7 @@ module ChefZero
           ChefZero::Log.error("Error loading cookbook #{name}: #{$!}\n  #{$!.backtrace.join("\n  ")}")
         end
       elsif has_child(directory, 'metadata.json')
-        metadata.from_json(read_file(directory, 'metadata.json'))
+        metadata.from_json(filename(directory, 'metadata.json'))
       end
       result = {}
       metadata.to_hash.each_pair do |key,value|


### PR DESCRIPTION
metadata.json contents are being read into from_json ... JSON.parse as a filename rather than passed the filename which from_json is actually expecting. This change passes in the filename of the metadata.json file rather than the contents.
