### PR TITLE
Simple basic auth ( replace of #85 )

### DIFF
--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -62,6 +62,10 @@ OptionParser.new do |opts|
     options[:ssl] = value
   end
 
+  opts.on("--auth-string STRING", "Set HTTP Basic Auth if given") do |value|
+    options[:auth_string] = value
+  end
+
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
     exit

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -233,7 +233,7 @@ module ChefZero
       if options[:auth_string]
         htp_file = Tempfile.new('dot.htpasswd')
         htpd = WEBrick::HTTPAuth::Htpasswd.new(htp_file.path)
-        htp_file.unlink
+        htp_file.close!
         htpd.set_passwd(nil, options[:auth_string], nil)
         authenticator = WEBrick::HTTPAuth::BasicAuth.new(:UserDB => htpd, :Realm => realm)
       end

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -231,7 +231,9 @@ module ChefZero
     def start_background(wait = 5)
       realm = "ChefZero's realm"
       if options[:auth_string]
-        htpd = WEBrick::HTTPAuth::Htpasswd.new('dot.htpasswd')
+        htp_file = Tempfile.new('dot.htpasswd')
+        htpd = WEBrick::HTTPAuth::Htpasswd.new(htp_file.path)
+        htp_file.unlink
         htpd.set_passwd(nil, options[:auth_string], nil)
         authenticator = WEBrick::HTTPAuth::BasicAuth.new(:UserDB => htpd, :Realm => realm)
       end


### PR DESCRIPTION
replace of #85

```
Add BasicAuth to chef-zero.

If given option `-auth-string STRING` or initialize ChefZero::Server with `:auth_string`  `server = ChefZero::Server.new(:auth_string => 'foobar')`, then chef_server_url will be provided as `'http://foobar@localhost:8889'`

UseCase:

1. We run chef-client local-mode on a shared-hosting server with recipe which spends long time.
2. The server listens local port during chef-client running.
3. Maybe, shared-hosting users could retrieve my cookbooks or other resources via http://localhost:8889.
```