### PR TITLE
add CORS header

### DIFF
--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -559,6 +559,9 @@ module ChefZero
           # Insert Server header
           response[1]['Server'] = 'chef-zero'
 
+          # Add CORS header
+          response[1]['Access-Control-Allow-Origin'] = '*'
+
           # Puma expects the response to be an array (chunked responses). Since
           # we are statically generating data, we won't ever have said chunked
           # response, so fake it.


### PR DESCRIPTION
This doesn't conform to the real Chef server behavior (yet), but it does allow you to use Chef Zero in a web browser, with jQuery, for example:

``` js
$.get('http://localhost:4000/nodes/desktop').then(function (data) { console.log(JSON.stringify(data)) });
// {"name":"desktop","json_class":"Chef::Node","chef_type":"node","chef_environment":"staging","override":{},"normal":{},"default":{},"automatic":{},"run_list":[]} 
// TADA!
```

Wasn't sure where to put a test for this. Where would that be?
