### PR TITLE
Return HTTP 400 Bad Request on Solr parse error

### DIFF
--- a/lib/chef_zero/endpoints/search_endpoint.rb
+++ b/lib/chef_zero/endpoints/search_endpoint.rb
@@ -13,6 +13,8 @@ module ChefZero
         results = search(request)
         results['rows'] = results['rows'].map { |name,uri,value,search_value| value }
         json_response(200, results)
+      rescue ChefZero::Solr::ParseError
+        bad_search_request(request)
       end
 
       def post(request)
@@ -41,9 +43,17 @@ module ChefZero
           'start' => full_results['start'],
           'total' => full_results['total']
         })
+      rescue ChefZero::Solr::ParseError
+        bad_search_request(request)
       end
 
       private
+
+      def bad_search_request(request)
+        query_string = request.query_params['q']
+        resp = {"error" => ["invalid search query: '#{query_string}'"]}
+        json_response(400, resp)
+      end
 
       def search_container(request, index)
         relative_parts, normalize_proc = case index

--- a/lib/chef_zero/solr/solr_parser.rb
+++ b/lib/chef_zero/solr/solr_parser.rb
@@ -7,6 +7,8 @@ require 'chef_zero/solr/query/subquery'
 
 module ChefZero
   module Solr
+    class ParseError < RuntimeError; end
+
     class SolrParser
       def initialize(query_string)
         @query_string = query_string
@@ -114,7 +116,7 @@ module ChefZero
       end
 
       def parse_error(token, str)
-        raise "Error on token '#{token}' at #{@index} of '#{@query_string}': #{str}"
+        raise ChefZero::Solr::ParseError, "Error on token '#{token}' at #{@index} of '#{@query_string}': #{str}"
       end
 
       def read_single_expression


### PR DESCRIPTION
Previously, chef-zero would return an HTTP 500 Internal Server Error
when the Solr parser failed.  Now, we return HTTP 400 with an error
message identical to that of the Erchef server. Returning HTTP 400
also improves the end-user experience since knife returns more
sensible error messages.

Before this patch:

    > knife search nodes 'recipes:bar::bar'
    ERROR: Server returned error 500 for http://127.0.0.1:8889/search...

After:

    > knife search nodes 'recipes:bar::bar'
    ERROR: knife search failed: invalid search query: 'recipes:bar::bar'