### PR TITLE
Make ChefZero aware of load balancers

### DIFF
--- a/lib/chef_zero/rest_request.rb
+++ b/lib/chef_zero/rest_request.rb
@@ -11,7 +11,13 @@ module ChefZero
     attr_accessor :rest_base_prefix
 
     def base_uri
-      @base_uri ||= "#{env['rack.url_scheme']}://#{env['HTTP_HOST']}#{env['SCRIPT_NAME']}"
+      # Load balancer awareness
+      if env['HTTP_X_FORWARDED_PROTO']
+        scheme = env['HTTP_X_FORWARDED_PROTO']
+      else
+        scheme = env['rack.url_scheme']
+      end
+      @base_uri ||= "#{scheme}://#{env['HTTP_HOST']}#{env['SCRIPT_NAME']}"
     end
 
     def base_uri=(value)


### PR DESCRIPTION
We have some complex reasons to hide a ChefZero behind an SSL nginx proxy.
One problem that suddenly arose with this is that URLs returned by
posting to /environment/foo/cookbook_versions use the protocol of the
internal webrick which is always plain http. This causes the chef client
to retrieve these urls on the https port but with an encrypted payload.

Support this situation by using the HTTP_X_FORWARDED_PROTO CGI variable
if it is available.