### PR TITLE
Policyfile Revision ID Validation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rest-client', :github => 'opscode/rest-client'
 
-gem 'chef-pedant', :github => 'opscode/chef-pedant', :tag => '1.0.44'
+gem 'chef-pedant', :github => 'opscode/chef-pedant', :tag => '1.0.46'
 
 gem 'chef', :github => 'opscode/chef', :tag => '12.1.0.rc.0'
 

--- a/lib/chef_zero/endpoints/policies_endpoint.rb
+++ b/lib/chef_zero/endpoints/policies_endpoint.rb
@@ -41,7 +41,8 @@ module ChefZero
 
       def validate(request)
         req_object = validate_json(request.body)
-        validate_name(request, req_object) ||
+        validate_revision_id(request, req_object) ||
+          validate_name(request, req_object) ||
           validate_run_list(req_object) ||
           validate_each_run_list_item(req_object) ||
           validate_cookbook_locks_collection(req_object) ||
@@ -52,6 +53,16 @@ module ChefZero
         FFI_Yajl::Parser.parse(request_body)
         # TODO: rescue parse error, return 400
         # error(400, "Must specify #{identity_keys.map { |k| k.inspect }.join(' or ')} in JSON")
+      end
+
+      def validate_revision_id(request, req_object)
+        if !req_object.key?("revision_id")
+          error(400, "Must specify 'revision_id' in JSON")
+        elsif req_object["revision_id"].size > 255
+          error(400, "'revision_id' field in JSON must be 255 characters or fewer")
+        elsif req_object["revision_id"] !~ /^[\-[:alnum:]_\.\:]+$/
+          error(400, "'revision_id' field in JSON must be contain only alphanumeric, hypen, underscore, and dot characters")
+        end
       end
 
       def validate_name(request, req_object)

--- a/lib/chef_zero/endpoints/policies_endpoint.rb
+++ b/lib/chef_zero/endpoints/policies_endpoint.rb
@@ -58,6 +58,8 @@ module ChefZero
       def validate_revision_id(request, req_object)
         if !req_object.key?("revision_id")
           error(400, "Must specify 'revision_id' in JSON")
+        elsif req_object["revision_id"].empty?
+          error(400, "'revision_id' field in JSON cannot be an empty string")
         elsif req_object["revision_id"].size > 255
           error(400, "'revision_id' field in JSON must be 255 characters or fewer")
         elsif req_object["revision_id"] !~ /^[\-[:alnum:]_\.\:]+$/


### PR DESCRIPTION
In the Policyfile draft RFC, `revision_id` is a required field. Add this validation to Chef Zero. This works locally with changes to pedant, but I can't commit those because erchef's policyfile validation is broken.

### See Also:

* ChefDK PR: https://github.com/chef/chef-dk/pull/323
* Pedant: https://github.com/chef/chef-pedant/pull/100
* Policyfile Draft RFC: https://github.com/chef/chef-rfc/pull/91