### PR TITLE
Partially Revert 1b2a6e5f107254cce8200a4750035b30265ae0c8

### DIFF
--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -98,7 +98,6 @@ module ChefZero
 
     GLOBAL_ENDPOINTS = [
       '/license',
-      '/users',
       '/version',
     ]
 
@@ -464,9 +463,9 @@ module ChefZero
       result = if options[:osc_compat]
         # OSC-only
         [
-          [ "/users", ActorsEndpoint.new(self) ],
-          [ "/users/*", ActorEndpoint.new(self) ],
-          [ "/authenticate_user", OrganizationAuthenticateUserEndpoint.new(self) ],
+          [ "/organizations/*/users", ActorsEndpoint.new(self) ],
+          [ "/organizations/*/users/*", ActorEndpoint.new(self) ],
+          [ "/organizations/*/authenticate_user", OrganizationAuthenticateUserEndpoint.new(self) ],
         ]
       else
         # EC-only
@@ -557,6 +556,7 @@ module ChefZero
       return proc do |env|
         begin
           prefix = global_endpoint?(env['PATH_INFO']) ? [] : rest_base_prefix
+
           request = RestRequest.new(env, prefix)
           if @on_request_proc
             @on_request_proc.call(request)


### PR DESCRIPTION
Currently, mounting the /users endpoint at the top level when in
osc_compat mode causes errrors in the Chef integration tests. This may
be due to a misconfiguration in the way Chef implements local mode but I
am unable to pinpoint the exact causes right now. In any case, this is
the minimal "revert" of 1b2a6e5f107254cce8200a4750035b30265ae0c8 that
gets Chef's integration tests working again.

@jkeiser @chef/client-core 