### PR TITLE
Socketless Requests

### DIFF
--- a/lib/chef_zero/rest_base.rb
+++ b/lib/chef_zero/rest_base.rb
@@ -195,8 +195,9 @@ module ChefZero
         # Strip off /organizations/chef if we are in single org mode
         if rest_path[0..1] != [ 'organizations', server.options[:single_org] ]
           raise "Unexpected URL #{rest_path[0..1]} passed to build_uri in single org mode"
+        else
+          "#{base_uri}/#{rest_path[2..-1].join('/')}"
         end
-        "#{base_uri}/#{rest_path[2..-1].join('/')}"
       else
         "#{base_uri}/#{rest_path.join('/')}"
       end

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -98,7 +98,6 @@ module ChefZero
 
     GLOBAL_ENDPOINTS = [
       '/license',
-      '/users',
       '/version',
     ]
 
@@ -464,9 +463,9 @@ module ChefZero
       result = if options[:osc_compat]
         # OSC-only
         [
-          [ "/users", ActorsEndpoint.new(self) ],
-          [ "/users/*", ActorEndpoint.new(self) ],
-          [ "/authenticate_user", OrganizationAuthenticateUserEndpoint.new(self) ],
+          [ "/organizations/*/users", ActorsEndpoint.new(self) ],
+          [ "/organizations/*/users/*", ActorEndpoint.new(self) ],
+          [ "/organizations/*/authenticate_user", OrganizationAuthenticateUserEndpoint.new(self) ],
         ]
       else
         # EC-only
@@ -557,6 +556,7 @@ module ChefZero
       return proc do |env|
         begin
           prefix = global_endpoint?(env['PATH_INFO']) ? [] : rest_base_prefix
+
           request = RestRequest.new(env, prefix)
           if @on_request_proc
             @on_request_proc.call(request)

--- a/lib/chef_zero/socketless_server_map.rb
+++ b/lib/chef_zero/socketless_server_map.rb
@@ -1,0 +1,84 @@
+#
+# Author:: Daniel DeLeo (<dan@chef.io>)
+# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'thread'
+require 'singleton'
+
+module ChefZero
+
+  class ServerNotFound < StandardError
+  end
+
+  class NoSocketlessPortAvailable < StandardError
+  end
+
+  class SocketlessServerMap
+
+    def self.request(port, request_env)
+      instance.request(port, request_env)
+    end
+
+    MUTEX = Mutex.new
+
+    include Singleton
+
+    def initialize()
+      reset!
+    end
+
+    def reset!
+      @servers_by_port = {}
+    end
+
+    def register_port(port, server)
+      MUTEX.synchronize do
+        @servers_by_port[port] = server
+      end
+    end
+
+    def register_no_listen_server(server)
+      MUTEX.synchronize do
+        1.upto(1000) do |port|
+          unless @servers_by_port.key?(port)
+            @servers_by_port[port] = server
+            return port
+          end
+        end
+        raise NoSocketlessPortAvailable, "No socketless ports left to register"
+      end
+    end
+
+    def has_server_on_port?(port)
+      @servers_by_port.key?(port)
+    end
+
+    def deregister(port)
+      MUTEX.synchronize do
+        @servers_by_port.delete(port)
+      end
+    end
+
+    def request(port, request_env)
+      server = @servers_by_port[port]
+      raise ServerNotFound, "No socketless chef-zero server on given port #{port.inspect}" unless server
+      server.handle_socketless_request(request_env)
+    end
+
+  end
+end
+

--- a/spec/socketless_server_map_spec.rb
+++ b/spec/socketless_server_map_spec.rb
@@ -1,0 +1,71 @@
+require 'chef_zero/socketless_server_map'
+
+
+describe "Socketless Mode" do
+
+  let(:server_map) { ChefZero::SocketlessServerMap.instance.tap { |i| i.reset! } }
+
+  let(:server) { instance_double("ChefZero::Server") }
+
+  let(:second_server) { instance_double("ChefZero::Server") }
+
+  it "registers a socketful server" do
+    server_map.register_port(8889, server)
+    expect(server_map).to have_server_on_port(8889)
+  end
+
+  context "when a no-listen server is registered" do
+
+    let!(:port) { server_map.register_no_listen_server(server) }
+
+    it "assigns the server a low port number" do
+      expect(port).to eq(1)
+    end
+
+    context "and another server is registered" do
+
+      let!(:next_port) { server_map.register_no_listen_server(second_server) }
+
+      it "assigns another port when another server is registered" do
+        expect(next_port).to eq(2)
+      end
+
+      it "raises NoSocketlessPortAvailable when too many servers are registered" do
+        expect { 1000.times { server_map.register_no_listen_server(server) } }.to raise_error(ChefZero::NoSocketlessPortAvailable)
+      end
+
+      it "deregisters a server" do
+        expect(server_map).to have_server_on_port(1)
+        server_map.deregister(1)
+        expect(server_map).to_not have_server_on_port(1)
+      end
+
+      describe "routing requests to a server" do
+
+        let(:rack_req) do
+          r = {}
+          r["REQUEST_METHOD"] = "GET"
+          r["SCRIPT_NAME"] = ""
+          r["PATH_INFO"] = "/clients"
+          r["QUERY_STRING"] = ""
+          r["rack.input"] = StringIO.new("")
+          r
+        end
+
+        let(:rack_response) { [200, {}, ["this is the response body"] ] }
+
+        it "routes a request to the registered port" do
+          expect(server).to receive(:handle_socketless_request).with(rack_req).and_return(rack_response)
+          response = server_map.request(1, rack_req)
+          expect(response).to eq(rack_response)
+        end
+
+        it "raises ServerNotFound when a request is sent to an unregistered port" do
+          expect { server_map.request(99, rack_req) }.to raise_error(ChefZero::ServerNotFound)
+        end
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
Allows Chef local mode to hit Chef Zero directly in-memory with no networking involved.

Note this branch includes https://github.com/chef/chef-zero/pull/120 which is what I needed to do to get the Chef integration tests passing for now, but if there's a better solution to that problem I'm more than happy to cherry-pick. Also I need to move the SocketlessServerMap to its own file, but some folks said they would try this code soon so I wanted to make it available.

@chef/client-core @jkeiser 