### PR TITLE
bump ffi-yajl dep

### DIFF
--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'mixlib-log',    '~> 1.3'
   s.add_dependency 'hashie',        '~> 2.0'
   s.add_dependency 'uuidtools', '~> 2.1'
-  s.add_dependency 'ffi-yajl', '~> 1.1'
+  s.add_dependency 'ffi-yajl', '>= 1.1', '< 3.0'
   s.add_dependency 'rack'
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
same change as chef and ohai, same rationale for not bumping the
lower bound to 2.0