### PR TITLE
Don't pollute global Chef server options

### DIFF
--- a/lib/chef_zero/rspec.rb
+++ b/lib/chef_zero/rspec.rb
@@ -54,16 +54,17 @@ module ChefZero
         end
 
         @@chef_server_options = { port: 8900, signals: false, log_requests: true, server_scope: :each }
-        chef_server_options.merge!(chef_zero_opts) if self.respond_to?(:chef_zero_opts)
-        chef_server_options.merge!(tags.last) if tags.last.is_a?(Hash)
-
-        Log.debug("Starting Chef server with options #{chef_server_options}")
+        chef_server_options = self.chef_server_options
+        chef_server_options = chef_server_options.merge(chef_zero_opts) if self.respond_to?(:chef_zero_opts)
+        chef_server_options = chef_server_options.merge(tags.last) if tags.last.is_a?(Hash)
 
         old_chef_server_url = nil
         old_node_name = nil
         old_client_key = nil
 
         before chef_server_options[:server_scope] do
+          Log.debug("Starting Chef server with options #{chef_server_options}")
+
           ChefZero::RSpec.set_server_options(chef_server_options)
 
           if chef_server_options[:organization]


### PR DESCRIPTION
This fixes an error where server configs are persisted between tests, so the last configuration set wins.