### PR TITLE
Adding `server_on_port` method to socketless server map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Chef Zero CHANGELOG
 ===================
 
+# Unrelesed
+
+* [PR#131](https://github.com/chef/chef-zero/pull/131): Adding new
+  `server_on_port` method to the socketless server map.
+
 # 4.2.1
 
 * [PR#125](https://github.com/chef/chef-zero/pull/125): Don't polute

--- a/lib/chef_zero/socketless_server_map.rb
+++ b/lib/chef_zero/socketless_server_map.rb
@@ -33,6 +33,10 @@ module ChefZero
       instance.request(port, request_env)
     end
 
+    def self.server_on_port(port)
+      instance.server_on_port(port)
+    end
+
     MUTEX = Mutex.new
 
     include Singleton
@@ -65,6 +69,10 @@ module ChefZero
 
     def has_server_on_port?(port)
       @servers_by_port.key?(port)
+    end
+
+    def server_on_port(port)
+      @servers_by_port[port]
     end
 
     def deregister(port)

--- a/spec/socketless_server_map_spec.rb
+++ b/spec/socketless_server_map_spec.rb
@@ -14,6 +14,11 @@ describe "Socketless Mode" do
     expect(server_map).to have_server_on_port(8889)
   end
 
+  it "retrieves a server by port" do
+    server_map.register_port(8889, server)
+    expect(ChefZero::SocketlessServerMap.server_on_port(8889)).to eq(server)
+  end
+
   context "when a no-listen server is registered" do
 
     let!(:port) { server_map.register_no_listen_server(server) }


### PR DESCRIPTION
To help with https://github.com/chef/chef-provisioning/pull/337

\cc @jkeiser @danielsdeleo 