### PR TITLE
add normal tags with empty array

### DIFF
--- a/lib/chef_zero/chef_data/data_normalizer.rb
+++ b/lib/chef_zero/chef_data/data_normalizer.rb
@@ -157,7 +157,7 @@ module ChefZero
         node['chef_type'] ||= 'node'
         node['chef_environment'] ||= '_default'
         node['override'] ||= {}
-        node['normal'] ||= {}
+        node['normal'] ||= {"tags" => []}
         node['default'] ||= {}
         node['automatic'] ||= {}
         node['run_list'] ||= []


### PR DESCRIPTION
normal has `tags` attributes with empty array. so let data_normalizer has it.
P.S. this fix in cooperation with @sawanoboly .