### PR TITLE
Remove dependency on chef

### DIFF
--- a/lib/chef_zero/endpoints/policies_endpoint.rb
+++ b/lib/chef_zero/endpoints/policies_endpoint.rb
@@ -1,8 +1,5 @@
 require 'ffi_yajl'
 
-require 'chef/version_class'
-require 'chef/exceptions'
-
 require 'chef_zero/endpoints/rest_object_endpoint'
 require 'chef_zero/chef_data/data_normalizer'
 
@@ -142,9 +139,9 @@ module ChefZero
       end
 
       def valid_version?(version_string)
-        Chef::Version.new(version_string)
+        Gem::Version.new(version_string)
         true
-      rescue Chef::Exceptions::InvalidCookbookVersion
+      rescue ArgumentError
         false
       end
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,4 +1,5 @@
 require 'chef_zero/server'
+require 'net/http'
 require 'uri'
 
 describe ChefZero::Server do


### PR DESCRIPTION
I am updating chef-zero in Debian, and when building the package in a clean environment (with no chef, and only the dependencies that are declared in the gemspec installed), tests fail. This PR has two commits that fix the issue for me.