### PR TITLE
Fix client-size databag hash-mashing

### DIFF
--- a/lib/chef_zero/chef_data/data_normalizer.rb
+++ b/lib/chef_zero/chef_data/data_normalizer.rb
@@ -64,10 +64,6 @@ module ChefZero
             data_bag_item['name'] ||= "data_bag_item_#{data_bag_name}_#{id}"
           end
         else
-          # If it's not already wrapped with raw_data, wrap it.
-          if data_bag_item['json_class'] == 'Chef::DataBagItem' && data_bag_item['raw_data']
-            data_bag_item = data_bag_item['raw_data']
-          end
           # Argh.  We don't do this on GET, but we do on PUT and POST????
           if %w(PUT POST).include?(method)
             data_bag_item['chef_type'] ||= 'data_bag_item'


### PR DESCRIPTION
@jkeiser this fixes a compatibility issue with the normal chef server.

The issue is that setting data_bag_item to just the raw data will return a non-serialized data_bag_item.

This will cause the chef-client to load it as a hash instead of loading it as an actual data_bag_item object. 

This will limit access of the data bag item to string only, where actual data_bag_item objects are mashes, and will support both string and symbolic access.

The practical problem here is that real cookbooks may use symbols, or a combination of symbols and strings to look up databags, as is the case with some of our cookbooks. This makes it impossible to use chef-zero without monkey patching.

I'm open to a better solution. Perhaps limiting the conditional below so that it will just ignore the GET method?

**note** this breaks data bag searching according to the tests, and I'm not sure why. There's probably a better fix.
