### PR TITLE
Switch to pedant in chef-server repo

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rest-client', :github => 'chef/rest-client'
 
-gem 'oc-chef-pedant', :github => 'chef/oc-chef-pedant', :tag => '2.0.0'
+gem 'oc-chef-pedant', :github => 'chef/chef-server'
 
 gem 'chef', :github => 'chef/chef', :tag => '12.4.1'
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -29,7 +29,9 @@ begin
   #Pedant::Config.rerun = true
 
   Pedant.config.suite = 'api'
+  Pedant.config.internal_server = 'http://localhost:8889'
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
+  Pedant.config[:server_api_version] = 0
   Pedant.setup([
     '--skip-knife',
     '--skip-keys',
@@ -40,8 +42,7 @@ begin
     '--skip-authorization',
     '--skip-omnibus',
     '--skip-usags',
-    '--skip-internal_orgs',
-    '--skip-rename_org',
+    '--exclude-internal-orgs',
     '--skip-headers'
   ])
 


### PR DESCRIPTION
Use the embedded pedant in the chef-server repo.  This also requires
slight changes to the pedant configuration, as the options have changed.