### PR TITLE
Fix scary search behavior on terms containing dash character

### DIFF
--- a/lib/chef_zero/solr/query/regexpable_query.rb
+++ b/lib/chef_zero/solr/query/regexpable_query.rb
@@ -21,8 +21,8 @@ module ChefZero
         end
 
         DEFAULT_FIELD = "text"
-        WORD_CHARACTER = "[A-Za-z0-9@._':]"
-        NON_WORD_CHARACTER = "[^A-Za-z0-9@._':]"
+        WORD_CHARACTER = "[A-Za-z0-9@._':\-]"
+        NON_WORD_CHARACTER = "[^A-Za-z0-9@._':\-]"
       end
     end
   end


### PR DESCRIPTION
Currently, dash character is defined as non-word character and it results into following search oddities:
```
$ knife node create mysql -d -z
Created node[mysql]
$ knife node create mysql-slave -d -z
Created node[mysql-slave]
$ knife search node 'name:mysql' -a name -z
2 items found

mysql:
  name: mysql

mysql-slave:
  name: mysql-slave

$ knife search node 'name:mysql?slave' -a name -z
0 items found

$ knife search node 'name:mysql-?lave' -a name -z
1 items found

mysql-slave:
  name: mysql-slave
```