### PR TITLE
Adding back logic to delete the association request when adding a user to an org (as well as adding the user to the groups)

### DIFF
--- a/lib/chef_zero/endpoints/organization_user_base.rb
+++ b/lib/chef_zero/endpoints/organization_user_base.rb
@@ -10,20 +10,6 @@ module ChefZero
         obj.json_response(200, result)
       end
 
-      def self.post(obj, request, key)
-        json = FFI_Yajl::Parser.parse(request.body, :create_additions => false)
-        username = json[key]
-        orgname = request.rest_path[1]
-        id = "#{username}-#{orgname}"
-
-        if obj.exists_data?(request, [ 'organizations', orgname, 'users', username ])
-          raise RestErrorResponse.new(409, "User #{username} is already in organization #{orgname}")
-        end
-
-        obj.create_data(request, request.rest_path, username, '{}')
-        obj.json_response(201, { "uri" => obj.build_uri(request.base_uri, request.rest_path + [ id ]) })
-      end
-
     end
   end
 end

--- a/lib/chef_zero/endpoints/organization_users_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_users_endpoint.rb
@@ -7,7 +7,32 @@ module ChefZero
     # /organizations/ORG/users
     class OrganizationUsersEndpoint < RestBase
       def post(request)
-        ChefZero::Endpoints::OrganizationUserBase.post(self, request, 'username')
+        orgname = request.rest_path[1]
+        json = FFI_Yajl::Parser.parse(request.body, :create_additions => false)
+        username = json['username']
+
+        if exists_data?(request, [ 'organizations', orgname, 'users', username ])
+          raise RestErrorResponse.new(409, "User #{username} is already in organization #{orgname}")
+        end
+
+        users = get_data(request, [ 'organizations', orgname, 'groups', 'users' ])
+        users = FFI_Yajl::Parser.parse(users, :create_additions => false)
+
+        create_data(request, request.rest_path, username, '{}')
+
+        # /organizations/ORG/association_requests/USERNAME-ORG
+        begin
+          delete_data(request, [ 'organizations', orgname, 'association_requests', username], :data_store_exceptions)
+        rescue DataStore::DataNotFoundError
+        end
+
+        # Add the user to the users group if it isn't already there
+        if !users['users'] || !users['users'].include?(username)
+          users['users'] ||= []
+          users['users'] |= [ username ]
+          set_data(request, [ 'organizations', orgname, 'groups', 'users' ], FFI_Yajl::Encoder.encode(users, :pretty => true))
+        end
+        json_response(201, { "uri" => build_uri(request.base_uri, request.rest_path + [ username ]) })
       end
 
       def get(request)


### PR DESCRIPTION
I think we over-simplified in https://github.com/chef/chef-zero/pull/146 - adding a user to an org was no longer removing the association request or adding the user to the groups.  I _think_ I have fixed this now.

The only reason I caught this was the failures coming from https://github.com/chef/cheffish/blob/17638eec1cee1efd1cd68e4c531d984b5201c214/spec/integration/chef_organization_spec.rb#L145-L153 - cheffish was testing to make sure chef-zero was removing the user from the association when it was added to the org.  There was no failing pedant test for this - I need to file a oc-chef-pedant issue to get this covered.

\cc @jkeiser @ssd @marcparadise @andrewjamesbrown