### PR TITLE
add patch to support chef_version

### DIFF
--- a/lib/chef_zero/chef_data/cookbook_data.rb
+++ b/lib/chef_zero/chef_data/cookbook_data.rb
@@ -124,11 +124,15 @@ module ChefZero
           self[key][cookbook] = version_constraints.first || ">= 0.0.0"
         end
 
-        def method_missing(key, value = nil)
-          if value.nil?
+        def method_missing(key, *values)
+          if values.nil?
             self[key.to_sym]
           else
-            store key.to_sym, value
+            if values.length > 1
+              store key.to_sym, values
+            else
+              store key.to_sym, values.first
+            end
           end
         end
       end


### PR DESCRIPTION
most of our metadata is the form of:

key "value"

but chef_version can be:

chef_version ">= 12.3.1", "< 13.0.0"

so we need a splat in method messing and need to shovel it into an
array.

relates to chef/chef#4081