### PR TITLE
Upgrade pedant, and enable running in ChefFS mode

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,4 @@ gem 'rest-client', :github => 'chef/rest-client'
 gem 'oc-chef-pedant', :path => "#{ENV['HOME']}/repos/chef-server"
 
 gem 'chef', :github => 'chef/chef'
+# gem 'chef', :path => "#{ENV['HOME']}/repos/chef"

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ gemspec
 gem 'rest-client', :github => 'chef/rest-client'
 
 # we were using e9bf7fe4440afd34856401831b30636100be958b, but now float on latest release.
-gem 'oc-chef-pedant', :github => 'chef/chef-server'
+# gem 'oc-chef-pedant', :github => 'chef/chef-server'
+gem 'oc-chef-pedant', :path => "#{ENV['HOME']}/repos/chef-server"
 
 gem 'chef', :github => 'chef/chef'

--- a/Gemfile
+++ b/Gemfile
@@ -5,10 +5,10 @@ gem 'rest-client', :github => 'chef/rest-client'
 
 # we were using e9bf7fe4440afd34856401831b30636100be958b, but now float on latest release.
 # gem 'oc-chef-pedant', :github => 'chef/chef-server'
-gem 'oc-chef-pedant', :path => "#{ENV['HOME']}/repos/chef-server"
+gem 'oc-chef-pedant', :path => "../chef-server"
 
 # bundler resolve failure on "rspec_junit_formatter"
 # gem 'chef-pedant', :github => 'opscode/chef-pedant', :ref => "server-cli-option"
 
 # gem 'chef', :github => 'chef/chef'
-gem 'chef', :path => "#{ENV['HOME']}/repos/chef"
+gem 'chef', :path => "../chef"

--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,8 @@ gem 'rest-client', :github => 'chef/rest-client'
 # gem 'oc-chef-pedant', :github => 'chef/chef-server'
 gem 'oc-chef-pedant', :path => "#{ENV['HOME']}/repos/chef-server"
 
-gem 'chef', :github => 'chef/chef'
-# gem 'chef', :path => "#{ENV['HOME']}/repos/chef"
+# bundler resolve failure on "rspec_junit_formatter"
+# gem 'chef-pedant', :github => 'opscode/chef-pedant', :ref => "server-cli-option"
+
+# gem 'chef', :github => 'chef/chef'
+gem 'chef', :path => "#{ENV['HOME']}/repos/chef"

--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,12 @@ gemspec
 gem 'rest-client', :github => 'chef/rest-client'
 
 # we were using e9bf7fe4440afd34856401831b30636100be958b, but now float on latest release.
-# gem 'oc-chef-pedant', :github => 'chef/chef-server'
-gem 'oc-chef-pedant', :path => "../chef-server"
+gem 'oc-chef-pedant', :github => 'chef/chef-server', :branch => 'jk/multiuser_tag'
+
+# gem 'oc-chef-pedant', :path => "../chef-server"
 
 # bundler resolve failure on "rspec_junit_formatter"
 # gem 'chef-pedant', :github => 'opscode/chef-pedant', :ref => "server-cli-option"
 
-# gem 'chef', :github => 'chef/chef'
-gem 'chef', :path => "../chef"
+gem 'chef', :github => 'chef/chef', :branch => 'invitations-and-members'
+# gem 'chef', :path => "../chef"

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,16 @@ task :pedant do
   require File.expand_path('spec/run_oc_pedant')
 end
 
+task :cheffs do
+  ENV['CHEF_FS'] = "yes"
+  require File.expand_path('spec/run_oc_pedant')
+end
+
+task :filestore do
+  ENV['FILE_STORE'] = "yes"
+  require File.expand_path('spec/run_oc_pedant')
+end
+
 desc "run oc pedant"
 task :oc_pedant do
   require File.expand_path('spec/run_oc_pedant')

--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,13 @@ task :pedant do
   require File.expand_path('spec/run_oc_pedant')
 end
 
+desc "run pedant with CHEF_FS set"
 task :cheffs do
   ENV['CHEF_FS'] = "yes"
   require File.expand_path('spec/run_oc_pedant')
 end
 
+desc "run pedant with FILE_STORE set"
 task :filestore do
   ENV['FILE_STORE'] = "yes"
   require File.expand_path('spec/run_oc_pedant')

--- a/lib/chef_zero/chef_data/default_creator.rb
+++ b/lib/chef_zero/chef_data/default_creator.rb
@@ -378,11 +378,12 @@ module ChefZero
           # Non-default containers do not get superusers added to them,
           # because reasons.
           unless path.size == 4 && path[0] == 'organizations' && path[2] == 'containers' && !exists?(path)
-            owners |= superusers
+            owners += superusers
           end
         end
 
-        owners.uniq
+        # we don't de-dup this list, because pedant expects to see ["pivotal", "pivotal"] in some cases.
+        owners
       end
 
       def default_acl(acl_path, acl={})

--- a/lib/chef_zero/endpoints/principal_endpoint.rb
+++ b/lib/chef_zero/endpoints/principal_endpoint.rb
@@ -8,16 +8,20 @@ module ChefZero
     class PrincipalEndpoint < RestBase
       def get(request)
         name = request.rest_path[-1]
+        # If /organizations/ORG/users/NAME exists, use this user (only org members have precedence over clients).        hey are an org member.
         json = get_data(request, request.rest_path[0..1] + [ 'users', name ], :nil)
         if json
           type = 'user'
           org_member = true
         else
+          # If /organizations/ORG/clients/NAME exists, use the client.
           json = get_data(request, request.rest_path[0..1] + [ 'clients', name ], :nil)
           if json
             type = 'client'
             org_member = true
           else
+            # If there is no client with that name, check for a user (/users/NAME) and return that with
+            # org_member = false.
             json = get_data(request, [ 'users', name ], :nil)
             if json
               type = 'user'

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -485,7 +485,7 @@ module ChefZero
 
     private
 
-    def open_source_endpoints
+    def endpoints
       result = if options[:osc_compat]
         # OSC-only
         [
@@ -581,7 +581,7 @@ module ChefZero
 
     def app
       return @app if @app
-      router = RestRouter.new(open_source_endpoints)
+      router = RestRouter.new(endpoints)
       router.not_found = NotFoundEndpoint.new
 
       if options[:single_org]

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -31,6 +31,8 @@ def start_cheffs_server(chef_repo_path)
   data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, 'pedant-testorg')
   data_store = ChefZero::DataStore::DefaultFacade.new(data_store, 'pedant-testorg', false)
   data_store.create(%w(organizations pedant-testorg users), 'pivotal', '{}')
+  data_store.set(%w(organizations pedant-testorg groups admins), '{ "users": [ "pivotal" ] }')
+  data_store.set(%w(organizations pedant-testorg groups users), '{ "users": [ "pivotal" ] }')
 
   server = ChefZero::Server.new(
     port: 8889,

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -77,7 +77,7 @@ begin
     [ '--skip-association',
       '--skip-users',
       '--skip-organizations',
-      '--skip-policies'        # these are expected to be broken.
+      '--skip-policies'        # these are expected to be broken, they're what we're trying to fix.
     ]
   else
     []

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -22,7 +22,7 @@ def start_cheffs_server(chef_repo_path)
   end
 
   # Start the new server
-  Chef::Config.repo_mode = 'everything'
+  Chef::Config.repo_mode = 'hosted_everything'
   Chef::Config.chef_repo_path = chef_repo_path
   Chef::Config.versioned_cookbooks = true
   chef_fs = Chef::ChefFS::Config.new.local_fs
@@ -74,7 +74,11 @@ begin
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
 
   chef_fs_skips = if ENV['CHEF_FS']
-    [ '--skip-association' ]
+    [ '--skip-association',
+      '--skip-users',
+      '--skip-organizations',
+      '--skip-policies'        # these are expected to be broken.
+    ]
   else
     []
   end
@@ -99,8 +103,8 @@ begin
     '--skip-api-v1'
   ] + chef_fs_skips)
 
-  # fail_fast = ["--fail-fast"]
   fail_fast = []
+  # fail_fast = ["--fail-fast"]
 
   result = RSpec::Core::Runner.run(Pedant.config.rspec_args + fail_fast)
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -77,7 +77,6 @@ begin
   Pedant::Config.search_url_fmt = "/dummy?fq=+X_CHEF_type_CHEF_X:%{type}&q=%{query}&wt=json"
 
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
-  Pedant.config[:server_api_version] = 0
 
   # "the goal is that only authorization, authentication and validation tests are turned off" - @jkeiser
   Pedant.setup([

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -56,7 +56,7 @@ begin
   elsif ENV['CHEF_FS']
     require 'tmpdir'
     tmpdir = Dir.mktmpdir
-    start_server(tmpdir)
+    server = start_server(tmpdir)
 
   else
     server = ChefZero::Server.new(:port => 8889, :single_org => false)#, :log_level => :debug)

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -67,11 +67,17 @@ begin
   require 'pedant'
   require 'pedant/organization'
 
-  Pedant::Config.rerun = true
+  # Pedant::Config.rerun = true
 
   Pedant.config.suite = 'api'
 
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
+
+  chef_fs_skips = if ENV['CHEF_FS']
+    [ '--skip-association' ]
+  else
+    []
+  end
 
   # "the goal is that only authorization, authentication and validation tests are turned off" - @jkeiser
   Pedant.setup([
@@ -91,9 +97,12 @@ begin
     '--skip-cookbook-artifacts',
     '--skip-containers',
     '--skip-api-v1'
-  ])
+  ] + chef_fs_skips)
 
-  result = RSpec::Core::Runner.run(Pedant.config.rspec_args)
+  # fail_fast = ["--fail-fast"]
+  fail_fast = []
+
+  result = RSpec::Core::Runner.run(Pedant.config.rspec_args + fail_fast)
 
   server.stop if server.running?
 ensure

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -67,7 +67,7 @@ begin
   require 'pedant'
   require 'pedant/organization'
 
-  # Pedant::Config.rerun = true
+  Pedant::Config.rerun = true
 
   Pedant.config.suite = 'api'
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -74,10 +74,13 @@ begin
 
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
 
+  # Because ChefFS can only ever have one user (pivotal), we can't do most of the
+  # tests that involve multiple
   chef_fs_skips = if ENV['CHEF_FS']
     [ '--skip-association',
       '--skip-users',
       '--skip-organizations',
+      '--skip-multiuser',
       '--skip-policies'        # these are expected to be broken, they're what we're trying to fix.
     ]
   else

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -26,8 +26,17 @@ def start_server(chef_repo_path)
   Chef::Config.chef_repo_path = chef_repo_path
   Chef::Config.versioned_cookbooks = true
   chef_fs = Chef::ChefFS::Config.new.local_fs
+
   data_store = Chef::ChefFS::ChefFSDataStore.new(chef_fs)
-  server = ChefZero::Server.new(:port => 8889, :single_org => false, :data_store => data_store)#, :log_level => :debug)
+  data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, 'pedant-testorg')
+  data_store = ChefZero::DataStore::DefaultFacade.new(data_store, 'pedant-testorg', false)
+
+  server = ChefZero::Server.new(
+    port: 8889,
+    data_store: data_store,
+    single_org: false,
+    #log_level: :debug
+  )
   server.start_background
   server
 end

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -25,9 +25,9 @@ def start_cheffs_server(chef_repo_path)
   Chef::Config.repo_mode = 'hosted_everything'
   Chef::Config.chef_repo_path = chef_repo_path
   Chef::Config.versioned_cookbooks = true
-  chef_fs = Chef::ChefFS::Config.new.local_fs
+  chef_fs_config = Chef::ChefFS::Config.new
 
-  data_store = Chef::ChefFS::ChefFSDataStore.new(chef_fs)
+  data_store = Chef::ChefFS::ChefFSDataStore.new(chef_fs_config.local_fs, chef_fs_config.chef_config)
   data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, 'pedant-testorg')
   data_store = ChefZero::DataStore::DefaultFacade.new(data_store, 'pedant-testorg', false)
   data_store.create(%w(organizations pedant-testorg users), 'pivotal', '{}')

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -30,6 +30,7 @@ def start_cheffs_server(chef_repo_path)
   data_store = Chef::ChefFS::ChefFSDataStore.new(chef_fs)
   data_store = ChefZero::DataStore::V1ToV2Adapter.new(data_store, 'pedant-testorg')
   data_store = ChefZero::DataStore::DefaultFacade.new(data_store, 'pedant-testorg', false)
+  data_store.create(%w(organizations pedant-testorg users), 'pivotal', '{}')
 
   server = ChefZero::Server.new(
     port: 8889,

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -70,11 +70,6 @@ begin
   # Pedant::Config.rerun = true
 
   Pedant.config.suite = 'api'
-  Pedant.config.internal_server = Pedant::Config.search_server = 'http://localhost:8889'
-
-  # see dummy_endpoint.rb.
-  Pedant.config.search_commit_url = "/dummy"
-  Pedant::Config.search_url_fmt = "/dummy?fq=+X_CHEF_type_CHEF_X:%{type}&q=%{query}&wt=json"
 
   Pedant.config[:config_file] = 'spec/support/oc_pedant.rb'
 
@@ -96,7 +91,6 @@ begin
     '--skip-cookbook-artifacts',
     '--skip-containers',
     '--skip-api-v1'
-
   ])
 
   result = RSpec::Core::Runner.run(Pedant.config.rspec_args)

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -5,7 +5,7 @@ require 'bundler/setup'
 require 'chef_zero/server'
 require 'rspec/core'
 
-def start_server(chef_repo_path)
+def start_cheffs_server(chef_repo_path)
   require 'chef/version'
   require 'chef/config'
   require 'chef/chef_fs/config'
@@ -56,7 +56,7 @@ begin
   elsif ENV['CHEF_FS']
     require 'tmpdir'
     tmpdir = Dir.mktmpdir
-    server = start_server(tmpdir)
+    server = start_cheffs_server(tmpdir)
 
   else
     server = ChefZero::Server.new(:port => 8889, :single_org => false)#, :log_level => :debug)

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -61,9 +61,12 @@ server_api_version 0
 # value.
 include_internal false
 
-# This is the bit that is different from pedant.rb
-org({:name => "pedant-testorg",
-     :create_me => true})
+key = 'spec/support/stickywicket.pem'
+
+org(name: "pedant-testorg",
+    create_me: true,
+    validator_key: key)
+
 internal_account_url chef_server
 delete_org true
 

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -47,6 +47,14 @@ explicit_port_url true
 
 server_api_version 0
 
+internal_server chef_server
+
+# see dummy_endpoint.rb for details.
+search_server   chef_server
+search_commit_url "/dummy"
+search_url_fmt    "/dummy?fq=+X_CHEF_type_CHEF_X:%{type}&q=%{query}&wt=json"
+
+
 # We're starting to break tests up into groups based on different
 # criteria.  The proper API tests (the results of which are viewable
 # to OPC customers) should be the only ones run by Pedant embedded in

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -45,6 +45,8 @@ maximum_search_time 0
 # # to be enabled for Pedant tests to work correctly
 explicit_port_url true
 
+server_api_version 0
+
 # We're starting to break tests up into groups based on different
 # criteria.  The proper API tests (the results of which are viewable
 # to OPC customers) should be the only ones run by Pedant embedded in

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -64,7 +64,7 @@ include_internal false
 key = 'spec/support/stickywicket.pem'
 
 org(name: "pedant-testorg",
-    create_me: true,
+    create_me: !ENV['CHEF_FS'],
     validator_key: key)
 
 internal_account_url chef_server

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -112,20 +112,20 @@ requestors({
                # An administrator in the testing organization
                :admin => {
                  :name => cheffs_or_else_user("pedant_admin_user"),
-                 :create_me => true,
+                 :create_me => !ENV['CHEF_FS'],
                  :create_knife => true
                },
 
                :non_admin => {
                  :name => cheffs_or_else_user("pedant_user"),
-                 :create_me => true,
+                 :create_me => !ENV['CHEF_FS'],
                  :create_knife => true
                },
 
                # A user that is not a member of the testing organization
                :bad => {
                  :name => cheffs_or_else_user("pedant-nobody"),
-                 :create_me => true,
+                 :create_me => !ENV['CHEF_FS'],
                  :create_knife => true,
                  :associate => false
                },

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -82,6 +82,10 @@ superuser_name 'pivotal'
 superuser_key key
 webui_key key
 
+def cheffs_or_else_user(value)
+  ENV['CHEF_FS'] ? "pivotal" : value
+end
+
 requestors({
              :clients => {
                # The the admin user, for the purposes of getting things rolling
@@ -107,20 +111,20 @@ requestors({
              :users => {
                # An administrator in the testing organization
                :admin => {
-                 :name => "pedant_admin_user",
+                 :name => cheffs_or_else_user("pedant_admin_user"),
                  :create_me => true,
                  :create_knife => true
                },
 
                :non_admin => {
-                 :name => "pedant_user",
+                 :name => cheffs_or_else_user("pedant_user"),
                  :create_me => true,
                  :create_knife => true
                },
 
                # A user that is not a member of the testing organization
                :bad => {
-                 :name => "pedant-nobody",
+                 :name => cheffs_or_else_user("pedant-nobody"),
                  :create_me => true,
                  :create_knife => true,
                  :associate => false

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -113,12 +113,14 @@ requestors({
                :admin => {
                  :name => cheffs_or_else_user("pedant_admin_user"),
                  :create_me => !ENV['CHEF_FS'],
+                 :associate => !ENV['CHEF_FS'],
                  :create_knife => true
                },
 
                :non_admin => {
                  :name => cheffs_or_else_user("pedant_user"),
                  :create_me => !ENV['CHEF_FS'],
+                 :associate => !ENV['CHEF_FS'],
                  :create_knife => true
                },
 

--- a/spec/support/oc_pedant.rb
+++ b/spec/support/oc_pedant.rb
@@ -86,6 +86,8 @@ def cheffs_or_else_user(value)
   ENV['CHEF_FS'] ? "pivotal" : value
 end
 
+keyfile_maybe = ENV['CHEF_FS'] ? { key_file: key } : { key_file: nil }
+
 requestors({
              :clients => {
                # The the admin user, for the purposes of getting things rolling
@@ -115,14 +117,14 @@ requestors({
                  :create_me => !ENV['CHEF_FS'],
                  :associate => !ENV['CHEF_FS'],
                  :create_knife => true
-               },
+               }.merge(keyfile_maybe),
 
                :non_admin => {
                  :name => cheffs_or_else_user("pedant_user"),
                  :create_me => !ENV['CHEF_FS'],
                  :associate => !ENV['CHEF_FS'],
                  :create_knife => true
-               },
+               }.merge(keyfile_maybe),
 
                # A user that is not a member of the testing organization
                :bad => {
@@ -130,7 +132,7 @@ requestors({
                  :create_me => !ENV['CHEF_FS'],
                  :create_knife => true,
                  :associate => false
-               },
+               }.merge(keyfile_maybe),
              }
            })
 


### PR DESCRIPTION
This has `chef-zero` run against the most recent version of `oc-chef-pedant` (currently 2.2.0, though we'll need to do a release due to a single change there), and has numerous changes to run with ChefFS as the backing store.

Depends on:
  - https://github.com/chef/chef-server/pull/622 (`oc-chef-pedant` tags and behavioral changes)
  - https://github.com/chef/chef/pull/4173 (ChefFS changes to handle invitations and members)