### PR TITLE
Ignore the universe endpoint tests in pedant

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rest-client', :github => 'chef/rest-client'
 
-gem 'oc-chef-pedant', :github => 'chef/chef-server'
+gem 'oc-chef-pedant', :github => 'chef/chef-server', :branch => 'tm/rfc-014-universe'
 
 # gem 'oc-chef-pedant', :path => "../chef-server"
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -106,7 +106,10 @@ begin
     # Chef 12 features not yet 100% supported by Chef Zero
     '--skip-cookbook-artifacts',
     '--skip-containers',
-    '--skip-api-v1'
+    '--skip-api-v1',
+
+    # The universe endpoint is unlikely to ever make sense for Chef Zero
+    '--skip-universe'
   ] + chef_fs_skips)
 
   fail_fast = []


### PR DESCRIPTION
chef/chef-server#645 implements the universe endpoint in chef-server. I can't really see any reason that you'd need or want a universe endpoint in zero, since it's mostly to allow berkshelf or Policyfiles to resolve the set of available cookbooks. 
This branch ignores the universe endpoint tests, and currently points at the branch in chef-server that implements them. That'll need to get updated before merge.