### PR TITLE
Lock rack version for Ruby < 2.2.2

### DIFF
--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -16,7 +16,12 @@ Gem::Specification.new do |s|
   s.add_dependency 'hashie',        '>= 2.0', '< 4.0'
   s.add_dependency 'uuidtools', '~> 2.1'
   s.add_dependency 'ffi-yajl', '~> 2.2'
-  s.add_dependency 'rack'
+
+  if defined?(RUBY_ENGINE) && RUBY_ENGINE == 'ruby' && RUBY_VERSION >= '2.2.2'
+    s.add_dependency 'rack'
+  else
+    s.add_dependency 'rack', '< 2.0'
+  end
 
   s.add_development_dependency 'pry'
   s.add_development_dependency 'pry-byebug'


### PR DESCRIPTION
Rack 2.0.0.apha has been pushed to Rubygems. It requires Ruby >= 2.2.2
and it breaks chef-zero on lower rubies when rack isn't previously
installed (`gem` command will pick up the newest possible version).