### PR TITLE
Internal orgs appears to be unused in oc-chef-pedant

### DIFF
--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -98,7 +98,6 @@ begin
     '--skip-keys',
     '--skip-controls',
     '--skip-acl',
-    '--exclude-internal-orgs',
     '--skip-headers',
 
     # Chef Zero does not intend to support validation the way erchef does.


### PR DESCRIPTION
This translates to excluding tests that are tagged `:internal_orgs`, but there aren't any such tests any more.