### PR TITLE
Make hoovering and deleting parent dir work everywhere for cookbook_artifacts

### DIFF
--- a/lib/chef_zero/endpoints/cookbook_artifact_endpoint.rb
+++ b/lib/chef_zero/endpoints/cookbook_artifact_endpoint.rb
@@ -2,7 +2,7 @@ require 'chef_zero/chef_data/data_normalizer'
 
 module ChefZero
   module Endpoints
-    class CookbookArtifactsCookbookEndpoint < RestBase
+    class CookbookArtifactEndpoint < RestBase
       # GET /organizations/ORG/cookbook_artifacts/COOKBOOK
       def get(request)
         cookbook_name = request.rest_path.last

--- a/lib/chef_zero/endpoints/cookbook_artifact_identifier_endpoint.rb
+++ b/lib/chef_zero/endpoints/cookbook_artifact_identifier_endpoint.rb
@@ -2,7 +2,7 @@ require 'chef_zero/chef_data/data_normalizer'
 
 module ChefZero
   module Endpoints
-    class CookbookArtifactsCookbookIdentifierEndpoint < ChefZero::Endpoints::CookbookVersionEndpoint
+    class CookbookArtifactIdentifierEndpoint < ChefZero::Endpoints::CookbookVersionEndpoint
       # these endpoints are almost, but not quite, not entirely unlike the corresponding /cookbooks endpoints.
       # it could all be refactored for maximum reuse, but they're short REST methods with well-defined
       # behavioral specs (pedant), so there's not a huge benefit.
@@ -36,9 +36,10 @@ module ChefZero
 
           # if this was the last revision, delete the directory so future requests will 404, instead of
           # returning 200 with an empty list.
-          artifact_path = request.rest_path[0..-2]
-          if list_data(request, artifact_path).size == 0
-            delete_data_dir(request, artifact_path)
+          # Last one out turns out the lights: delete /organizations/ORG/cookbooks/COOKBOOK if it no longer has versions
+          cookbook_path = request.rest_path[0..3]
+          if exists_data_dir?(request, cookbook_path) && list_data(request, cookbook_path).size == 0
+            delete_data_dir(request, cookbook_path)
           end
 
           json_response(200, identified_cookbook_data)

--- a/lib/chef_zero/endpoints/cookbook_artifacts_cookbook_identifier.rb
+++ b/lib/chef_zero/endpoints/cookbook_artifacts_cookbook_identifier.rb
@@ -32,7 +32,7 @@ module ChefZero
           delete_data(request)
 
           # go through the recipes and delete stuff in the file store.
-          hoover_unused_checksums(get_checksums(doomed_cookbook_json), request, 'cookbook_artifacts')
+          hoover_unused_checksums(get_checksums(doomed_cookbook_json), request)
 
           # if this was the last revision, delete the directory so future requests will 404, instead of
           # returning 200 with an empty list.

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -45,9 +45,9 @@ require 'chef_zero/endpoints/actor_endpoint'
 require 'chef_zero/endpoints/cookbooks_endpoint'
 require 'chef_zero/endpoints/cookbook_endpoint'
 require 'chef_zero/endpoints/cookbook_version_endpoint'
-require 'chef_zero/endpoints/cookbook_artifacts_cookbook_endpoint'
-require 'chef_zero/endpoints/cookbook_artifacts_cookbook_identifier'
 require 'chef_zero/endpoints/cookbook_artifacts_endpoint'
+require 'chef_zero/endpoints/cookbook_artifact_endpoint'
+require 'chef_zero/endpoints/cookbook_artifact_identifier_endpoint'
 require 'chef_zero/endpoints/containers_endpoint'
 require 'chef_zero/endpoints/container_endpoint'
 require 'chef_zero/endpoints/dummy_endpoint'
@@ -567,8 +567,8 @@ module ChefZero
         [ "/organizations/*/cookbooks/*", CookbookEndpoint.new(self) ],
         [ "/organizations/*/cookbooks/*/*", CookbookVersionEndpoint.new(self) ],
         [ "/organizations/*/cookbook_artifacts", CookbookArtifactsEndpoint.new(self) ],
-        [ "/organizations/*/cookbook_artifacts/*", CookbookArtifactsCookbookEndpoint.new(self) ],
-        [ "/organizations/*/cookbook_artifacts/*/*", CookbookArtifactsCookbookIdentifierEndpoint.new(self) ],
+        [ "/organizations/*/cookbook_artifacts/*", CookbookArtifactEndpoint.new(self) ],
+        [ "/organizations/*/cookbook_artifacts/*/*", CookbookArtifactIdentifierEndpoint.new(self) ],
         [ "/organizations/*/data", DataBagsEndpoint.new(self) ],
         [ "/organizations/*/data/*", DataBagEndpoint.new(self) ],
         [ "/organizations/*/data/*/*", DataBagItemEndpoint.new(self) ],


### PR DESCRIPTION
- Right now, there are multiple calls to hoover_delete_checksums but we only override one of them.
- This patch also fixes the spot where we delete /cookbook_artifacts/name when the last /cookbook_artifacts/name/identifier is removed.