### PR TITLE
Enable knife pedant tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.1
+      env: PEDANT_KNIFE_TESTS=true
+    - rvm: 2.1
       env: SINGLE_ORG=true
     - rvm: 2.1
       env: CHEF_FS=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
     - rvm: 2.0
     - rvm: 2.1
     - rvm: 2.1
-      env: PEDANT_KNIFE_TESTS=true
+      env: PEDANT_KNIFE_TESTS=true PEDANT_ALLOW_RVM=1
     - rvm: 2.1
       env: SINGLE_ORG=true
     - rvm: 2.1

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 gem 'rest-client', :github => 'chef/rest-client'
 
-gem 'oc-chef-pedant', :github => 'chef/chef-server'
+gem 'oc-chef-pedant', :github => 'chef/chef-server', :branch => 'allow-optional-rvm'
 
 # gem 'oc-chef-pedant', :path => "../chef-server"
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -94,9 +94,12 @@ begin
     []
   end
 
-  # "the goal is that only authorization, authentication and validation tests are turned off" - @jkeiser
-  Pedant.setup([
-    '--skip-knife',
+  # These things aren't supported by Chef Zero in any mode of operation:
+  default_skips = [
+    # "the goal is that only authorization, authentication and validation tests
+    # are turned off" - @jkeiser
+    #
+    # ...but we're not there yet
     '--skip-keys',
     '--skip-controls',
     '--skip-acl',
@@ -129,7 +132,18 @@ begin
 
     # The universe endpoint is unlikely to ever make sense for Chef Zero
     '--skip-universe'
-  ] + chef_fs_skips)
+  ]
+
+  # The knife tests are very slow and don't give us a lot of extra coverage,
+  # so we run them in a different entry in the travis test matrix.
+  pedant_args =
+    if ENV["PEDANT_KNIFE_TESTS"]
+      default_skips + %w{ --focus-knife }
+    else
+      default_skips + chef_fs_skips + %w{ --skip-knife }
+    end
+
+  Pedant.setup(pedant_args)
 
   fail_fast = []
   # fail_fast = ["--fail-fast"]


### PR DESCRIPTION
These tests are quite slow, so I added them as a separate travis test matrix entry. They will only run against the in-memory data store. This should be a good compromise between test completeness and speed.