### PR TITLE
fix necessary for metadata gem

### DIFF
--- a/lib/chef_zero/chef_data/cookbook_data.rb
+++ b/lib/chef_zero/chef_data/cookbook_data.rb
@@ -108,6 +108,11 @@ module ChefZero
           cookbook_arg(:replacing, cookbook, version_constraints)
         end
 
+        def gem(*opts)
+          self[:gems] ||= []
+          self[:gems] << opts
+        end
+
         def recipe(recipe, description)
           self[:recipes][recipe] = description
         end


### PR DESCRIPTION
there's a Kernel#gem method in ruby because someone thought that would
be a great idea, kind of messes up method_missing when the method isn't
missing...