### PR TITLE
support URI specific character in file name

### DIFF
--- a/lib/chef_zero/rest_base.rb
+++ b/lib/chef_zero/rest_base.rb
@@ -80,6 +80,7 @@ module ChefZero
 
     def get_data(request, rest_path=nil, *options)
       rest_path ||= request.rest_path
+      rest_path = rest_path.map { |v| URI.decode(v) }
       begin
         data_store.get(rest_path, request)
       rescue DataStore::DataNotFoundError
@@ -276,7 +277,7 @@ module ChefZero
     end
 
     def self.build_uri(base_uri, rest_path)
-      "#{base_uri}/#{rest_path.join('/')}"
+      "#{base_uri}/#{rest_path.map { |v| URI.escape(v) }.join('/')}"
     end
 
     def populate_defaults(request, response)


### PR DESCRIPTION
If file name includes URL meta characters, knife can't get that file.
So I add URI escape and decode for URI.