### PR TITLE
Fix bugs related to Array vs Enumerator vs Port for options[:port/host].

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-rvm: 2.0
+rvm: 2.1
 gemfile: Gemfile
 
 # This prevents testing branches that are created just for PRs
@@ -18,8 +18,6 @@ script:
 
 matrix:
   include:
-    - rvm: 2.0
-    - rvm: 2.1
     - rvm: 2.1
       env: PEDANT_KNIFE_TESTS=true PEDANT_ALLOW_RVM=1
     - rvm: 2.1

--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |s|
   s.homepage = 'http://www.opscode.com'
   s.license = 'Apache 2.0'
 
+  s.required_ruby_version = ">= 2.1.0"
+
   s.add_dependency 'mixlib-log',    '~> 1.3'
   s.add_dependency 'hashie',        '>= 2.0', '< 4.0'
   s.add_dependency 'uuidtools', '~> 2.1'

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -142,6 +142,7 @@ module ChefZero
     def port
       if @port
         @port
+      # If options[:port] is not an Array or an Enumerable, it is just an Integer.
       elsif !options[:port].respond_to?(:each)
         options[:port]
       else
@@ -164,10 +165,11 @@ module ChefZero
     #
     def url
       sch = @options[:ssl] ? 'https' : 'http'
-      @url ||= if @options[:host].first.include?(':')
-                 URI("#{sch}://[#{@options[:host].first}]:#{port}").to_s
+      hosts = Array(@options[:host])
+      @url ||= if hosts.first.include?(':')
+                 URI("#{sch}://[#{hosts.first}]:#{port}").to_s
                else
-                 URI("#{sch}://#{@options[:host].first}:#{port}").to_s
+                 URI("#{sch}://#{hosts.first}:#{port}").to_s
                end
     end
 
@@ -292,8 +294,10 @@ module ChefZero
       @server.mount('/', Rack::Handler::WEBrick, app)
 
       # Pick a port
-      [options[:port]].flatten.each do |port|
-        if listen(options[:host], port)
+      # If options[:port] can be an Enumerator, an Array, or an Integer,
+      # we need something that can respond to .each (Enum and Array can already).
+      Array(options[:port]).each do |port|
+        if listen(Array(options[:host]), port)
           @port = port
           break
         end


### PR DESCRIPTION
[options[:port]].flatten does not do the right thing in the case that options[:port] is an Enumerator.

options[:host] is not always an Array (can be a String).