### PR TITLE
Log responses only at debug log level

### DIFF
--- a/lib/chef_zero/rest_router.rb
+++ b/lib/chef_zero/rest_router.rb
@@ -60,7 +60,7 @@ module ChefZero
       end
 
       def log_response(response)
-        ChefZero::Log.info {
+        ChefZero::Log.debug {
           [ "",
             "--- RESPONSE (#{response[0]}) ---",
             response[2].chomp,


### PR DESCRIPTION
Logging these at info means that when a user runs:

    chef-client -z

They may get all of their cookbook content logged to their terminal
(depending out their outputting options).  Since INFO is the default 
log_level for non-tty devices, this has a big impact on what people 
might see in their system log files or CI systems.