### PR TITLE
Set log level to debug in the rescue block.

### DIFF
--- a/lib/chef_zero/rest_base.rb
+++ b/lib/chef_zero/rest_base.rb
@@ -61,7 +61,7 @@ module ChefZero
       begin
         self.send(method, request)
       rescue RestErrorResponse => e
-        ChefZero::Log.info("#{e.inspect}\n#{e.backtrace.join("\n")}")
+        ChefZero::Log.debug("#{e.inspect}\n#{e.backtrace.join("\n")}")
         error(e.response_code, e.error)
       end
     end


### PR DESCRIPTION
This fixes the problem at the beginning of chef-zero run:

```
[2016-07-06T23:11:17+00:00] INFO: #<ChefZero::RestErrorResponse: 404: Object not found: chefzero://localhost:8889/nodes/vagrant-ubuntu-trusty-64>
```

It doesn't influence the run but it confuses the users as it looks like a failure.