### PR TITLE
Support clients and users fields in ACL PUT requests

### DIFF
--- a/lib/chef_zero/chef_data/data_normalizer.rb
+++ b/lib/chef_zero/chef_data/data_normalizer.rb
@@ -8,8 +8,18 @@ module ChefZero
       def self.normalize_acls(acls)
         ChefData::DefaultCreator::PERMISSIONS.each do |perm|
           acls[perm] ||= {}
-          (acls[perm]["actors"] ||= []).uniq! # this gets doubled sometimes, for reasons.
           acls[perm]["groups"] ||= []
+          if acls[perm].has_key? "users"
+            # When clients and users are split, their combined list
+            # is the final list of actors that a subsequent GET will
+            # provide. Each list is guaranteed to be unique, but the
+            # combined list is not.
+            acls[perm]["actors"] = acls[perm].delete("users").uniq +
+              acls[perm].delete("clients").uniq
+          else
+            # this gets doubled sometimes, for reasons.
+            (acls[perm]["actors"] ||= []).uniq!
+          end
         end
         acls
       end

--- a/lib/chef_zero/version.rb
+++ b/lib/chef_zero/version.rb
@@ -1,3 +1,3 @@
 module ChefZero
-  VERSION = "4.9.0"
+  VERSION = "4.9.1"
 end


### PR DESCRIPTION
This brings pedant up to date with changes to the ACLs endpoiint that are currently in flight.   When 'clients' and 'users' are included in an ACL PUT, that is combined to form the list of actors. 
