### PR TITLE
store ACEs by client/user

### DIFF
--- a/lib/chef_zero/chef_data/data_normalizer.rb
+++ b/lib/chef_zero/chef_data/data_normalizer.rb
@@ -14,8 +14,8 @@ module ChefZero
             # is the final list of actors that a subsequent GET will
             # provide. Each list is guaranteed to be unique, but the
             # combined list is not.
-            acls[perm]["actors"] = acls[perm].delete("users").uniq +
-              acls[perm].delete("clients").uniq
+            acls[perm]["actors"] = acls[perm]["clients"].uniq +
+              acls[perm]["users"].uniq
           else
             # this gets doubled sometimes, for reasons.
             (acls[perm]["actors"] ||= []).uniq!

--- a/lib/chef_zero/endpoints/acls_endpoint.rb
+++ b/lib/chef_zero/endpoints/acls_endpoint.rb
@@ -22,6 +22,17 @@ module ChefZero
         end
         acls = FFI_Yajl::Parser.parse(get_data(request, acl_path), :create_additions => false)
         acls = ChefData::DataNormalizer.normalize_acls(acls)
+        if request.query_params["detail"] == "granular"
+          acls.each do |perm, ace|
+            acls[perm]["actors"] = []
+          end
+        else
+          acls.each do |perm, ace|
+            acls[perm].delete("clients")
+            acls[perm].delete("users")
+          end
+        end
+
         json_response(200, acls)
       end
     end


### PR DESCRIPTION
Chef Server has the ability to return users and clients separately
within an GET ACL request when `detail=granular`.  To support that,
we need to store them separately and determine if we want to present
`actors` or `users` and `clients` at the time of the request.

This change makes a reasonable best effort at capturing the creator
type (user v client) correctly and uses that for determining its
assignment in acls.