### PR TITLE
Handle the start and rows parameters correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source "https://rubygems.org"
 gemspec
 
-# gem 'rest-client', :github => 'chef/rest-client'
+# gem 'rest-client', :git => 'https://github.com/chef/rest-client.git'
 
-gem "oc-chef-pedant", :github => "chef/chef-server"
+gem "oc-chef-pedant", :git => "https://github.com/chef/chef-server.git"
 
 group :changelog do
   gem "github_changelog_generator"
@@ -13,10 +13,7 @@ group :development, :test do
   gem "chefstyle", "= 0.3.1"
 end
 
-# bundler resolve failure on "rspec_junit_formatter"
-# gem 'chef-pedant', :github => 'opscode/chef-pedant', :ref => "server-cli-option"
-
-gem "chef", github: "chef/chef" # until chef 12.15 is released
+gem "chef"
 
 if ENV["GEMFILE_MOD"]
   puts "GEMFILE_MOD: #{ENV['GEMFILE_MOD']}"

--- a/lib/chef_zero/endpoints/search_endpoint.rb
+++ b/lib/chef_zero/endpoints/search_endpoint.rb
@@ -12,7 +12,19 @@ module ChefZero
       def get(request)
         orgname = request.rest_path[1]
         results = search(request, orgname)
+
         results["rows"] = results["rows"].map { |name, uri, value, search_value| value }
+
+        # Slice the array based on the value of the "rows" query parameter. If
+        # this is a positive integer, we'll get the number of rows asked for.
+        # If it's nil, we'll get -1, which gives us all of the elements.
+        #
+        # Do the same for "start", which will start at 0 if that value is not
+        # given.
+        results["rows"] =
+          results["rows"][request.query_params["start"].to_i..
+                          (request.query_params["rows"].to_i - 1)]
+
         json_response(200, results)
       rescue ChefZero::Solr::ParseError
         bad_search_request(request)


### PR DESCRIPTION
Chef Zero would, on a search request using the "start" or "rows"
parameters, always return all rows.

This change makes it so only the correct number of rows are returned or
the results start at the correct index.

This change will make the tests added in oc-chef-pedant in
chef/chef-server#1028 pass.

Also update the Gemfile to use HTTPS URLs for Git sources, remove unused
comments, and use the Chef Gem from RubyGems as the previous comment
suggested.

![giphy6](https://cloud.githubusercontent.com/assets/9912/20874905/c9605b20-ba7b-11e6-8058-617ba99d8d64.gif)
