### PR TITLE
implement rfc090 for named nodes endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
   - bundle update
   - bundle exec rake pedant
 env:
-  - "PEDANT_OPTS=\"--skip-oc_id\""
+  global:
+    - "PEDANT_OPTS=\"--skip-oc_id\""
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ cache: bundler
 script:
   - bundle update
   - bundle exec rake pedant
-env:
-  global:
-    - "PEDANT_OPTS=\"--skip-oc_id\""
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ cache: bundler
 script:
   - bundle update
   - bundle exec rake pedant
+env:
+  - "PEDANT_OPTS=\"--skip-oc_id\""
 
 matrix:
   include:

--- a/lib/chef_zero/endpoints/node_endpoint.rb
+++ b/lib/chef_zero/endpoints/node_endpoint.rb
@@ -21,7 +21,7 @@ module ChefZero
       end
 
       def head(request)
-        response_to_head(request)
+        head_request(request)
       end
 
       def populate_defaults(request, response_json)

--- a/lib/chef_zero/endpoints/node_endpoint.rb
+++ b/lib/chef_zero/endpoints/node_endpoint.rb
@@ -20,6 +20,10 @@ module ChefZero
         super(request)
       end
 
+      def head(request)
+        response_to_head(request)
+      end
+
       def populate_defaults(request, response_json)
         node = FFI_Yajl::Parser.parse(response_json)
         node = ChefData::DataNormalizer.normalize_node(node, request.rest_path[3])

--- a/lib/chef_zero/rest_base.rb
+++ b/lib/chef_zero/rest_base.rb
@@ -231,6 +231,16 @@ module ChefZero
       [response_code, { "Content-Type" => "text/plain" }, text]
     end
 
+    # rfc090
+    # @param [ChefZero::RestRequest] request The HTTP request object
+    #
+    # @return [Fixnum], [nil]
+    #
+    def response_to_head(request)
+      get_data(request) # will raise 404 if non-existant
+      json_response(200, nil)
+    end
+
     # Returns an Array with the response code, HTTP headers, and JSON body.
     #
     # @param [Fixnum] response_code The HTTP response code

--- a/lib/chef_zero/rest_base.rb
+++ b/lib/chef_zero/rest_base.rb
@@ -231,12 +231,12 @@ module ChefZero
       [response_code, { "Content-Type" => "text/plain" }, text]
     end
 
-    # rfc090
+    # rfc090 returns 404 error or 200 with an emtpy body
     # @param [ChefZero::RestRequest] request The HTTP request object
     #
-    # @return [Fixnum], [nil]
+    # @return (see #json_response)
     #
-    def response_to_head(request)
+    def head_request(request)
       get_data(request) # will raise 404 if non-existant
       json_response(200, nil)
     end

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -161,6 +161,10 @@ begin
     # Chef Zero does not intend to support authorization the way erchef does.
     "--skip-authorization",
 
+    # Chef Zero does not intend to support oc_id authentication/authorization
+    # the way erchef does.
+    "--skip-oc_id",
+
     # Omnibus tests depend on erchef features that are specific to erchef and
     # bundled in the omnibus package. Currently the only test in this category
     # is for the search reindexing script.


### PR DESCRIPTION
This is a first stab at implementing rfc090 (HTTP HEAD) support.
For right now, it only covers the named nodes endpoint ('/nodes/NAME').  However, it can easily be added to other endpoints as needed.

Signed-off-by: Jeremy J. Miller <jm@chef.io>