### PR TITLE
GET /users?email=ME@MINE.COM -- compare emails ignoring case

### DIFF
--- a/lib/chef_zero/endpoints/actors_endpoint.rb
+++ b/lib/chef_zero/endpoints/actors_endpoint.rb
@@ -13,7 +13,7 @@ module ChefZero
         if value = request.query_params["external_authentication_uid"]
           response[2] = filter("external_authentication_uid", value, request, response[2])
         elsif value = request.query_params["email"]
-          response[2] = filter("email", value, request, response[2])
+          response[2] = filter("email", value, request, response[2], insensitive: true)
         end
 
         if request.query_params["verbose"]
@@ -83,17 +83,21 @@ module ChefZero
 
       private
 
-      def filter(key, value, request, resp)
+      def filter(key, value, request, resp, opts = {})
         results = parse_json(resp)
         new_results = {}
         results.each do |name, url|
           record = get_data(request, request.rest_path + [ name ], :nil)
           if record
             record = parse_json(record)
-            new_results[name] = url if record[key] == value
+            new_results[name] = url if record[key] && is_equal(record[key], value, opts[:insensitive])
           end
         end
         to_json(new_results)
+      end
+
+      def is_equal(a, b, ignore_case)
+        ignore_case ? a.casecmp(b).zero? : a == b
       end
     end
   end


### PR DESCRIPTION
As of POOL-608, the query will return users with the mail `me@mine.com`,
too. While this is technically a little incorrect (only the host part is
case insensitive), most mail providers treat the user part as case
insensitive as well.

Note that this implies that the response may involve more than one user.
But chef-zero behaves like chef-server does, returning them all.

Signed-off-by: Stephan Renatus <srenatus@chef.io>