### PR TITLE
add the universe endpoint

### DIFF
--- a/lib/chef_zero/endpoints/cookbooks_base.rb
+++ b/lib/chef_zero/endpoints/cookbooks_base.rb
@@ -23,6 +23,24 @@ module ChefZero
         results
       end
 
+      def format_universe_list(request, cookbooks_list)
+        require 'pp'
+        results = {}
+        cookbooks_list.each do |name, versions|
+          results[name] ||= {}
+          versions.each do |version|
+            cookbook_data = FFI_Yajl::Parser.parse(get_data(request, request.rest_path[0..1] + [ "cookbooks", name, version ], :nil))
+            pp cookbook_data
+            results[name][version] ||= {
+              "dependencies" => cookbook_data["metadata"]["dependencies"],
+              "location_path" => build_uri(request.base_uri, request.rest_path[0..1] + ["cookbooks", name, version]),
+              "location_type" => "chef_server",
+            }
+          end
+        end
+        results
+      end
+
       def all_cookbooks_list(request)
         result = {}
         # Race conditions exist here (if someone deletes while listing).  I don't care.

--- a/lib/chef_zero/endpoints/cookbooks_base.rb
+++ b/lib/chef_zero/endpoints/cookbooks_base.rb
@@ -24,13 +24,11 @@ module ChefZero
       end
 
       def format_universe_list(request, cookbooks_list)
-        require 'pp'
         results = {}
         cookbooks_list.each do |name, versions|
           results[name] ||= {}
           versions.each do |version|
             cookbook_data = FFI_Yajl::Parser.parse(get_data(request, request.rest_path[0..1] + [ "cookbooks", name, version ], :nil))
-            pp cookbook_data
             results[name][version] ||= {
               "dependencies" => cookbook_data["metadata"]["dependencies"],
               "location_path" => build_uri(request.base_uri, request.rest_path[0..1] + ["cookbooks", name, version]),

--- a/lib/chef_zero/endpoints/universe_endpoint.rb
+++ b/lib/chef_zero/endpoints/universe_endpoint.rb
@@ -1,0 +1,15 @@
+require "ffi_yajl"
+require "chef_zero/endpoints/rest_object_endpoint"
+require "chef_zero/chef_data/data_normalizer"
+
+module ChefZero
+  module Endpoints
+    # /universe
+    class UniverseEndpoint < CookbooksBase
+
+      def get(request)
+        json_response(200, format_universe_list(request, all_cookbooks_list(request)))
+      end
+    end
+  end
+end

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -1,6 +1,6 @@
 #
 # Author:: John Keiser (<jkeiser@opscode.com>)
-# Copyright:: Copyright (c) 2012 Opscode, Inc.
+# Copyright:: Copyright (c) 2012-2017, Chef Software Inc.
 # License:: Apache License, Version 2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -105,6 +105,7 @@ require "chef_zero/endpoints/file_store_file_endpoint"
 require "chef_zero/endpoints/not_found_endpoint"
 require "chef_zero/endpoints/version_endpoint"
 require "chef_zero/endpoints/server_api_version_endpoint"
+require "chef_zero/endpoints/universe_endpoint"
 
 module ChefZero
 
@@ -623,6 +624,7 @@ module ChefZero
         [ "/organizations/*/sandboxes/*", SandboxEndpoint.new(self) ],
         [ "/organizations/*/search", SearchesEndpoint.new(self) ],
         [ "/organizations/*/search/*", SearchEndpoint.new(self) ],
+        [ "/organizations/*/universe", UniverseEndpoint.new(self) ],
         [ "/version", VersionEndpoint.new(self) ],
         [ "/server_api_version", ServerAPIVersionEndpoint.new(self) ],
 

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -179,9 +179,6 @@ begin
 
     # Chef 12 features not yet 100% supported by Chef Zero
 
-    # The universe endpoint is unlikely to ever make sense for Chef Zero
-    "--skip-universe",
-
     # chef-zero has some non-removable quirks, such as the fact that files
     # with 255-character names cannot be stored in local mode. This is
     # reserved only for quirks that are *irrevocable* and by design; and


### PR DESCRIPTION
because it makes sense for chef-zero

i need it for integration testing against berks to kill off the
uses of the berkshelf-api gem.

closes #153 