### PR TITLE
Fix default perms on cookbook_artifact objects

### DIFF
--- a/lib/chef_zero/endpoints/cookbook_artifact_identifier_endpoint.rb
+++ b/lib/chef_zero/endpoints/cookbook_artifact_identifier_endpoint.rb
@@ -20,7 +20,7 @@ module ChefZero
         end
 
         cb_data = normalize(request, request.body)
-        set_data(request, nil, to_json(cb_data), :create_dir)
+        set_data(request, nil, to_json(cb_data), :create_dir, :create)
 
         return already_json_response(201, request.body)
       end


### PR DESCRIPTION
The ACLs for `cookbook_artifact` objects currently do not include the
creator of the object.  Adding the `:create` option to the `set_data`
call (which forwards it on to the `set` method on the data store),
allows the `cookbook_artifact` object to have the creator added to its
ACL.

Signed-off-by: Nolan Davidson <ndavidson@chef.io>