### PR TITLE
Disable Hashie method override warns

### DIFF
--- a/lib/chef_zero/chef_data/cookbook_data.rb
+++ b/lib/chef_zero/chef_data/cookbook_data.rb
@@ -2,6 +2,10 @@ require "digest/md5"
 require "hashie"
 
 module ChefZero
+  class Mash < ::Hashie::Mash
+    disable_warnings
+  end
+
   module ChefData
     module CookbookData
       class << self
@@ -175,7 +179,7 @@ module ChefZero
           name(cookbook.name)
           recipes(cookbook.fully_qualified_recipe_names)
           %w{attributes grouping dependencies supports recommendations suggestions conflicting providing replacing recipes}.each do |hash_arg|
-            self[hash_arg.to_sym] = Hashie::Mash.new
+            self[hash_arg.to_sym] = Mash.new
           end
         end
 


### PR DESCRIPTION
I'm seeing some warnings coming from Hashie, but the issue for me seems to be overriding `Mash.zip`. Here's the upstream issue: https://github.com/intridea/hashie/issues/423 and [hashie's response for disabling warnings](https://github.com/intridea/hashie/pull/395). 

The [`github` gem does this same fix](https://github.com/piotrmurach/github/blob/master/lib/github_api/mash.rb). 

```
W, [2018-03-15T15:16:39.602423 #24086]  WARN -- : You are setting a key that conflicts with a built-in method Hashie::Mash#zip defined in Enumerable. This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.
```
