### PR TITLE
Add ChefZero::Dist to abstract branding details to a single location

### DIFF
--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -7,6 +7,7 @@ require "rubygems"
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
 
 require "chef_zero/log"
+require "chef_zero/dist"
 require "chef_zero/version"
 require "chef_zero/server"
 require "chef_zero/data_store/raw_file_store"
@@ -28,7 +29,7 @@ end
 options = {}
 
 OptionParser.new do |opts|
-  opts.banner = "Usage: chef-zero [ARGS]"
+  opts.banner = "Usage: #{ChefZero::Dist::CLIENT} [ARGS]"
 
   opts.on("-H", "--host HOST", "Host to bind to (default: 127.0.0.1)") do |value|
     options[:host] ||= []
@@ -100,7 +101,7 @@ if options[:daemon]
     server.start(true)
   else
     if ENV["OS"] == "Windows_NT"
-      abort "Daemonization is not supported on Windows. Running 'start chef-zero' will fork the process."
+      abort "Daemonization is not supported on Windows. Running 'start #{ChefZero::Dist::CLIENT}' will fork the process."
     else
       abort "Process.daemon requires Ruby >= 1.9"
     end

--- a/lib/chef_zero/dist.rb
+++ b/lib/chef_zero/dist.rb
@@ -1,0 +1,9 @@
+module ChefZero
+  class Dist
+    # When referencing a product directly
+    PRODUCT = "Chef Zero".freeze
+
+    # The binary alias
+    CLIENT = "chef-zero".freeze
+  end
+end

--- a/lib/chef_zero/endpoints/controls_endpoint.rb
+++ b/lib/chef_zero/endpoints/controls_endpoint.rb
@@ -1,14 +1,15 @@
+require "chef_zero/dist"
 module ChefZero
   module Endpoints
     # /organizations/ORG/controls
     class ControlsEndpoint < RestBase
       # ours is not to wonder why; ours is but to make the pedant specs pass.
       def get(request)
-        error(410, "Server says 410, chef-zero says 410.")
+        error(410, "Server says 410, #{ChefZero::Dist::CLIENT} says 410.")
       end
 
       def post(request)
-        error(410, "Server says 410, chef-zero says 410.")
+        error(410, "Server says 410, #{ChefZero::Dist::CLIENT} says 410.")
       end
     end
   end

--- a/lib/chef_zero/endpoints/version_endpoint.rb
+++ b/lib/chef_zero/endpoints/version_endpoint.rb
@@ -1,11 +1,12 @@
 require "chef_zero/rest_base"
+require "chef_zero/dist"
 
 module ChefZero
   module Endpoints
     # /version
     class VersionEndpoint < RestBase
       def get(request)
-        text_response(200, "chef-zero #{ChefZero::VERSION}\n")
+        text_response(200, "#{ChefZero::Dist::CLIENT} #{ChefZero::VERSION}\n")
       end
     end
   end

--- a/lib/chef_zero/rspec.rb
+++ b/lib/chef_zero/rspec.rb
@@ -42,7 +42,7 @@ module ChefZero
     extend RSpecClassMethods
 
     def when_the_chef_server(description, *tags, &block)
-      context "When the Chef server #{description}", *tags do
+      context "When the #{ChefZero::Dist::PRODUCT} server #{description}", *tags do
         extend WhenTheChefServerClassMethods
         include WhenTheChefServerInstanceMethods
 
@@ -69,7 +69,7 @@ module ChefZero
           if chef_server_options[:server_scope] != self.class.chef_server_options[:server_scope]
             raise "server_scope: #{chef_server_options[:server_scope]} will not be honored: it can only be set on when_the_chef_server!"
           end
-          Log.info("Starting Chef server with options #{chef_server_options}")
+          Log.info("Starting #{ChefZero::Dist::PRODUCT} server with options #{chef_server_options}")
 
           ChefZero::RSpec.set_server_options(chef_server_options)
 

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -35,6 +35,7 @@ require "chef_zero/data_store/memory_store_v2"
 require "chef_zero/data_store/v1_to_v2_adapter"
 require "chef_zero/data_store/default_facade"
 require "chef_zero/version"
+require "chef_zero/dist.rb"
 
 require "chef_zero/endpoints/rest_list_endpoint"
 require "chef_zero/endpoints/authenticate_user_endpoint"
@@ -231,7 +232,7 @@ module ChefZero
       if publish
         output = publish.respond_to?(:puts) ? publish : STDOUT
         output.puts <<-EOH.gsub(/^ {10}/, "")
-          >> Starting Chef Zero (v#{ChefZero::VERSION})...
+          >> Starting #{ChefZero::Dist::PRODUCT} (v#{ChefZero::VERSION})...
         EOH
       end
 
@@ -248,7 +249,7 @@ module ChefZero
 
       %w{INT TERM}.each do |signal|
         Signal.trap(signal) do
-          puts "\n>> Stopping Chef Zero..."
+          puts "\n>> Stopping #{ChefZero::Dist::PRODUCT}..."
           @server.shutdown
         end
       end
@@ -362,7 +363,7 @@ module ChefZero
       end
     rescue Timeout::Error
       if @thread
-        ChefZero::Log.error("Chef Zero did not stop within #{wait} seconds! Killing...")
+        ChefZero::Log.error("#{ChefZero::Dist::PRODUCT} did not stop within #{wait} seconds! Killing...")
         @thread.kill
         SocketlessServerMap.deregister(port)
       end

--- a/lib/chef_zero/socketless_server_map.rb
+++ b/lib/chef_zero/socketless_server_map.rb
@@ -18,6 +18,7 @@
 
 require "thread"
 require "singleton"
+require "chef_zero/dist"
 
 module ChefZero
 
@@ -83,7 +84,7 @@ module ChefZero
 
     def request(port, request_env)
       server = @servers_by_port[port]
-      raise ServerNotFound, "No socketless chef-zero server on given port #{port.inspect}" unless server
+      raise ServerNotFound, "No socketless #{ChefZero::Dist::PRODUCT} server on given port #{port.inspect}" unless server
       server.handle_socketless_request(request_env)
     end
 


### PR DESCRIPTION
Related to chef/chef's [#8376](https://github.com/chef/chef/issues/8376) design proposal to set brands in a single location for easy patching by community distributions.

## Description
- Add a dist.rb file defining the PRODUCT and CLIENT constants to be used in outputs.
- Replace occurences of chef-zero and Chef-Zero by their constant counterparts.
- add a require "chef_zero/dist.rb" to files updated on point above

## Related Issue

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
