### PR TITLE
Add option to increase the number of clients/threads in web server (backport of #294 to v13.1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ You may currently pass the following options to the initializer:
 - `host` - the host to run on (Default: '127.0.0.1')
 - `port` - the port to run on (Default: 8889)
 - `debug` - run in debug mode to see all requests and responses (Default: false)
+- `maxclients` - the number of threads to serve requests in WEBrick (Default: 100)
 
 ## CLI (Command Line)
 
@@ -141,6 +142,7 @@ Usage: chef-zero [ARGS]
         --multi-org                  Whether to run in multi-org mode
         --file-store PATH            Persist data to files at the given path
         --[no-]ssl                   Use SSL with self-signed certificate(Auto generate before every run).  Default: false.
+        --maxclients NUM             MaxClients for WEBrick.  Default: 100.
     -h, --help                       Show this message
         --version                    Show version
 ```

--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -74,7 +74,7 @@ OptionParser.new do |opts|
   end
 
   opts.on("--maxclients NUM", "MaxClients for WEBrick.  Default: 100.") do |value|
-    options[:maxclients] = value
+    options[:maxclients] = value.to_i
   end
 
   opts.on_tail("-h", "--help", "Show this message") do

--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -73,6 +73,10 @@ OptionParser.new do |opts|
     options[:ssl] = value
   end
 
+  opts.on("--maxclients NUM", "MaxClients for WEBrick.  Default: 100.") do |value|
+    options[:maxclients] = value
+  end
+
   opts.on_tail("-h", "--help", "Show this message") do
     puts opts
     exit

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -292,7 +292,7 @@ module ChefZero
         :StartCallback => proc do
           @running = true
         end,
-        :MaxClients => options[:maxclients],
+        :MaxClients => options[:maxclients]
       )
       ENV["HTTPS"] = "on" if options[:ssl]
       @server.mount("/", Rack::Handler::WEBrick, app)

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -118,6 +118,7 @@ module ChefZero
       :generate_real_keys => true,
       :single_org => "chef",
       :ssl => false,
+      :maxclients => 100,
     }.freeze
 
     GLOBAL_ENDPOINTS = [
@@ -290,7 +291,8 @@ module ChefZero
         :SSLCertName => [ [ "CN", WEBrick::Utils.getservername ] ],
         :StartCallback => proc do
           @running = true
-        end
+        end,
+        :MaxClients => options[:maxclients],
       )
       ENV["HTTPS"] = "on" if options[:ssl]
       @server.mount("/", Rack::Handler::WEBrick, app)


### PR DESCRIPTION
This is a backport of #294 to v13.1.0 tag.

chef-zero is used for spinning up a Chef server for taste-tester (https://github.com/facebook/taste-tester). We've built futher automation around this and have run into practical limits on the number of clients that can reliably retrieve data via https.

## Description
chef-zero uses WEBrick to serve https. The default number of request is tied to the default number of threads in WEBrick, which appears to be 100. As this is a subordinate component we need a way to pass in a different value so we can increase the the limit where needed.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

There's no new tests to test this, because actually testing the effects of maxclients being set is difficult to verify or falsify - due to timing.
