### PR TITLE
Optimize requires for non-omnibus installs

### DIFF
--- a/lib/chef_zero/data_store/raw_file_store.rb
+++ b/lib/chef_zero/data_store/raw_file_store.rb
@@ -19,7 +19,7 @@
 require_relative "data_already_exists_error"
 require_relative "data_not_found_error"
 require_relative "interface_v2"
-require "fileutils"
+require "fileutils" unless defined?(FileUtils)
 
 module ChefZero
   module DataStore

--- a/lib/chef_zero/endpoints/acl_endpoint.rb
+++ b/lib/chef_zero/endpoints/acl_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/acl_path"
 

--- a/lib/chef_zero/endpoints/acls_endpoint.rb
+++ b/lib/chef_zero/endpoints/acls_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/data_normalizer"
 require_relative "../chef_data/acl_path"

--- a/lib/chef_zero/endpoints/actor_endpoint.rb
+++ b/lib/chef_zero/endpoints/actor_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/actors_endpoint.rb
+++ b/lib/chef_zero/endpoints/actors_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_list_endpoint"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/authenticate_user_endpoint.rb
+++ b/lib/chef_zero/endpoints/authenticate_user_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/container_endpoint.rb
+++ b/lib/chef_zero/endpoints/container_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/containers_endpoint.rb
+++ b/lib/chef_zero/endpoints/containers_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_list_endpoint"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/cookbook_version_endpoint.rb
+++ b/lib/chef_zero/endpoints/cookbook_version_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../rest_error_response"
 require_relative "../chef_data/data_normalizer"

--- a/lib/chef_zero/endpoints/cookbooks_base.rb
+++ b/lib/chef_zero/endpoints/cookbooks_base.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/data_bag_endpoint.rb
+++ b/lib/chef_zero/endpoints/data_bag_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_list_endpoint"
 require_relative "data_bag_item_endpoint"
 require_relative "../rest_error_response"

--- a/lib/chef_zero/endpoints/data_bag_item_endpoint.rb
+++ b/lib/chef_zero/endpoints/data_bag_item_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "data_bag_item_endpoint"
 require_relative "../chef_data/data_normalizer"

--- a/lib/chef_zero/endpoints/data_bags_endpoint.rb
+++ b/lib/chef_zero/endpoints/data_bags_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_list_endpoint"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/environment_cookbook_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_cookbook_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "cookbooks_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_cookbook_versions_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../rest_error_response"
 

--- a/lib/chef_zero/endpoints/environment_cookbooks_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_cookbooks_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "cookbooks_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/environment_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/environment_nodes_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_nodes_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/environment_recipes_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_recipes_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "cookbooks_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/environment_role_endpoint.rb
+++ b/lib/chef_zero/endpoints/environment_role_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "cookbooks_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/group_endpoint.rb
+++ b/lib/chef_zero/endpoints/group_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/groups_endpoint.rb
+++ b/lib/chef_zero/endpoints/groups_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_list_endpoint"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/license_endpoint.rb
+++ b/lib/chef_zero/endpoints/license_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/node_endpoint.rb
+++ b/lib/chef_zero/endpoints/node_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/node_identifiers_endpoint.rb
+++ b/lib/chef_zero/endpoints/node_identifiers_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require "uuidtools"
 

--- a/lib/chef_zero/endpoints/nodes_endpoint.rb
+++ b/lib/chef_zero/endpoints/nodes_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/not_found_endpoint.rb
+++ b/lib/chef_zero/endpoints/not_found_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module ChefZero
   module Endpoints

--- a/lib/chef_zero/endpoints/organization_association_request_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_association_request_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_association_requests_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_association_requests_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_authenticate_user_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_authenticate_user_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_user_base.rb
+++ b/lib/chef_zero/endpoints/organization_user_base.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_user_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_user_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/organization_users_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_users_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "organization_user_base"
 

--- a/lib/chef_zero/endpoints/organization_validator_key_endpoint.rb
+++ b/lib/chef_zero/endpoints/organization_validator_key_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require "uuidtools"
 

--- a/lib/chef_zero/endpoints/organizations_endpoint.rb
+++ b/lib/chef_zero/endpoints/organizations_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require "uuidtools"
 

--- a/lib/chef_zero/endpoints/policy_group_endpoint.rb
+++ b/lib/chef_zero/endpoints/policy_group_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/policy_group_policy_endpoint.rb
+++ b/lib/chef_zero/endpoints/policy_group_policy_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/policy_groups_endpoint.rb
+++ b/lib/chef_zero/endpoints/policy_groups_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/principal_endpoint.rb
+++ b/lib/chef_zero/endpoints/principal_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../../chef_zero"
 require_relative "../rest_base"
 

--- a/lib/chef_zero/endpoints/rest_list_endpoint.rb
+++ b/lib/chef_zero/endpoints/rest_list_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/rest_object_endpoint.rb
+++ b/lib/chef_zero/endpoints/rest_object_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 require_relative "../rest_error_response"
 

--- a/lib/chef_zero/endpoints/role_endpoint.rb
+++ b/lib/chef_zero/endpoints/role_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/role_environments_endpoint.rb
+++ b/lib/chef_zero/endpoints/role_environments_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/sandbox_endpoint.rb
+++ b/lib/chef_zero/endpoints/sandbox_endpoint.rb
@@ -1,6 +1,6 @@
 require_relative "../rest_base"
 require_relative "../rest_error_response"
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 
 module ChefZero
   module Endpoints

--- a/lib/chef_zero/endpoints/sandboxes_endpoint.rb
+++ b/lib/chef_zero/endpoints/sandboxes_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/search_endpoint.rb
+++ b/lib/chef_zero/endpoints/search_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 require_relative "../rest_error_response"

--- a/lib/chef_zero/endpoints/system_recovery_endpoint.rb
+++ b/lib/chef_zero/endpoints/system_recovery_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/universe_endpoint.rb
+++ b/lib/chef_zero/endpoints/universe_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "rest_object_endpoint"
 require_relative "../chef_data/data_normalizer"
 

--- a/lib/chef_zero/endpoints/user_association_request_endpoint.rb
+++ b/lib/chef_zero/endpoints/user_association_request_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/user_association_requests_count_endpoint.rb
+++ b/lib/chef_zero/endpoints/user_association_requests_count_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/user_association_requests_endpoint.rb
+++ b/lib/chef_zero/endpoints/user_association_requests_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/endpoints/user_organizations_endpoint.rb
+++ b/lib/chef_zero/endpoints/user_organizations_endpoint.rb
@@ -1,4 +1,4 @@
-require "ffi_yajl"
+require "ffi_yajl" unless defined?(FFI_Yajl)
 require_relative "../rest_base"
 
 module ChefZero

--- a/lib/chef_zero/rest_router.rb
+++ b/lib/chef_zero/rest_router.rb
@@ -1,4 +1,4 @@
-require "pp"
+require "pp" unless defined?(PP)
 
 module ChefZero
   class RestRouter

--- a/lib/chef_zero/rspec.rb
+++ b/lib/chef_zero/rspec.rb
@@ -1,4 +1,4 @@
-require "tempfile"
+require "tempfile" unless defined?(Tempfile)
 require_relative "server"
 require_relative "rest_request"
 

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -16,14 +16,14 @@
 # limitations under the License.
 #
 
-require "openssl"
+require "openssl" unless defined?(OpenSSL)
 require "open-uri"
-require "rubygems"
-require "timeout"
-require "stringio"
+require "rubygems" unless defined?(Gem)
+require "timeout" unless defined?(Timeout)
+require "stringio" unless defined?(StringIO)
 
-require "rack"
-require "webrick"
+require "rack" unless defined?(Rack)
+require "webrick" unless defined?(WEBrick)
 require "webrick/https"
 
 require_relative "../chef_zero"

--- a/lib/chef_zero/socketless_server_map.rb
+++ b/lib/chef_zero/socketless_server_map.rb
@@ -17,7 +17,7 @@
 #
 
 require "thread"
-require "singleton"
+require "singleton" unless defined?(Singleton)
 require_relative "dist"
 
 module ChefZero


### PR DESCRIPTION
require is quite slow in Ruby and doing requires for things you've already required is also slow. We've used this simple hack in Chef to speed up our requires. In the omnibus installs we patch how rubygems works to make this somewhat pointless, but this will help non-omnibus installs

Signed-off-by: Tim Smith <tsmith@chef.io>