### PR TITLE
Optimize our requires

### DIFF
--- a/bin/chef-zero
+++ b/bin/chef-zero
@@ -3,7 +3,7 @@
 # Trap interrupts to quit cleanly.
 Signal.trap("INT") { exit 1 }
 
-require "rubygems"
+require "rubygems" unless defined?(Gem)
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "..", "lib")))
 
 require "chef_zero/log"

--- a/lib/chef_zero/server.rb
+++ b/lib/chef_zero/server.rb
@@ -17,7 +17,7 @@
 #
 
 require "openssl" unless defined?(OpenSSL)
-require "open-uri"
+require "open-uri" unless defined?(OpenURI)
 require "rubygems" unless defined?(Gem)
 require "timeout" unless defined?(Timeout)
 require "stringio" unless defined?(StringIO)

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require "json"
+require "json" unless defined?(JSON)
 require "bundler"
 require "bundler/setup"
 
@@ -93,7 +93,7 @@ begin
   tmpdir = nil
   server =
     if ENV["FILE_STORE"]
-      require "tmpdir"
+      require "tmpdir" unless defined?(Dir.mktmpdir)
       require "chef_zero/data_store/raw_file_store"
       tmpdir = Dir.mktmpdir
       data_store = ChefZero::DataStore::RawFileStore.new(tmpdir, true)
@@ -102,7 +102,7 @@ begin
       start_chef_server(data_store: data_store)
 
     elsif ENV["CHEF_FS"]
-      require "tmpdir"
+      require "tmpdir" unless defined?(Dir.mktmpdir)
       tmpdir = Dir.mktmpdir
       start_cheffs_server(tmpdir)
 

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,6 +1,6 @@
 require "chef_zero/server"
-require "net/http"
-require "uri"
+require "net/http" unless defined?(Net::HTTP)
+require "uri" unless defined?(URI)
 
 describe ChefZero::Server do
   context "with a server bound to port 8889" do


### PR DESCRIPTION
Avoid requiring things that are already defined. Rubygems is very slow at traversing the filesystem.

Signed-off-by: Tim Smith <tsmith@chef.io>