### PR TITLE
Zei/skipping status for pedant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ tmp
 rspec.failures
 gemfiles/*.lock
 .ruby-version
+.idea/

--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -188,6 +188,8 @@ begin
     # tests from chef-server as the user acls are not supported in chef-zero
     # at this time.
     "--skip-chef-zero-quirks",
+
+    "--skip-status"
   ]
 
   # The knife tests are very slow and don't give us a lot of extra coverage,


### PR DESCRIPTION


## Description
The test case for `/_status` is added to the pedant project as part of configuring the status endpoint in chef-server. Since this endpoint is not there in chef-zero, skipping this test case while running pedant.

## Related Issue
https://github.com/chef/chef-server/issues/2214

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
