### PR TITLE
Skipping nginx default error response verification pedant test

### DIFF
--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -190,7 +190,8 @@ begin
     "--skip-chef-zero-quirks",
 
     "--skip-status",
-    "--skip=email_case_insensitive"
+    "--skip=email_case_insensitive",
+    "--skip=nginx_default_error"
   ]
 
   # The knife tests are very slow and don't give us a lot of extra coverage,


### PR DESCRIPTION
Signed-off-by: jan shahid shaik <jashaik@progress.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
Chef-zero is for testing against a "real" Chef Server without mocking the entire Internet.
This pedant test is to verify the openresty tags in the nginx default error responses, chef-zero is just mock the chef-server not nginx component So we are skipping this test for now.

## Related Issue
Skipping the test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
