### PR TITLE
Skipping response header test for pedant

### DIFF
--- a/spec/run_oc_pedant.rb
+++ b/spec/run_oc_pedant.rb
@@ -191,7 +191,8 @@ begin
 
     "--skip-status",
     "--skip=email_case_insensitive",
-    "--skip=nginx_default_error"
+    "--skip=nginx_default_error",
+    "--skip=response_headers"
   ]
 
   # The knife tests are very slow and don't give us a lot of extra coverage,


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

## Description
The `x-ops-api-info` variable in the header is made configurable through `chef-server.rb`. The pedant test for the same uses `chef-server-running.json` to validate the test. Since `chef-server-running.json` file is not present in the chef-zero, skipping this test.

## Related Issue
https://github.com/chef/chef-server/pull/2815

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
