### PR TITLE
Updating the policy_revision_endpoint to add policy_group_list

### DIFF
--- a/lib/chef_zero/endpoints/policy_revision_endpoint.rb
+++ b/lib/chef_zero/endpoints/policy_revision_endpoint.rb
@@ -7,7 +7,50 @@ module ChefZero
       # GET /organizations/ORG/policies/NAME/revisions/REVISION
       def get(request)
         data = parse_json(get_data(request))
-        data = ChefData::DataNormalizer.normalize_policy(data, request.rest_path[3], request.rest_path[5])
+        
+        # need to add another field in the response called 'policy_group_list'
+        # example response
+        #     {
+        #       "revision_id": "909c26701e291510eacdc6c06d626b9fa5350d25",
+        #       "name": "some_policy_name",
+        #       "run_list": [
+        #         "recipe[policyfile_demo::default]"
+        #       ],
+        #       "cookbook_locks": {
+        #         "policyfile_demo": {
+        #           "identifier": "f04cc40faf628253fe7d9566d66a1733fb1afbe9",
+        #           "version": "1.2.3"
+        #         }
+        #       },
+        #       "policy_group_list": ["some_policy_group"]
+        #     }
+        data[:policy_group_list] = Array.new
+
+        # extracting policy name and revision
+        request_policy_name = request.rest_path[3]
+        request_policy_revision = request.rest_path[5]
+
+        # updating the request to fetch the policy group list
+        request.rest_path[2] = "policy_groups"
+        request.rest_path = request.rest_path.slice(0,3)
+
+        list_data(request).each do |group_name|
+          group_path = request.rest_path + [group_name]
+
+          # fetching all the policies associated with each group
+          policy_list = list_data(request, group_path + ["policies"])
+          policy_list.each do |policy_name|
+            revision_id = parse_json(get_data(request, group_path + ["policies", policy_name]))
+
+            # if the name and revision matchs, we add the group to the response
+            if (policy_name == request_policy_name) && (revision_id == request_policy_revision)
+              policy_group_list = data[:policy_group_list]
+              data[:policy_group_list] = [group_name] + policy_group_list
+            end
+          end
+        end
+        
+        data = ChefData::DataNormalizer.normalize_policy(data, request_policy_name, request_policy_revision)
         json_response(200, data)
       end
 


### PR DESCRIPTION
Signed-off-by: Vinay Satish <vinay.satish@progress.com>

## Description
The API - `/organizations/[organization_id]/policies/[policy_name/revisions/[revision_id]` was updated in the Chef Infra Server to include `policy_group_list` in its response. Even the pedant tests were updated as part of this change.

This PR has the same changes in chef-zero to keep the APIs consistent between Chef Infra Server and chef zero.

## Related Issue
https://github.com/chef/chef-server/pull/2818
https://github.com/chef/chef-server/issues/2867

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
