### PR TITLE
[SandboxesEndpoint#put] Move checksum discovery out of loop

### DIFF
--- a/lib/chef_zero/endpoints/sandboxes_endpoint.rb
+++ b/lib/chef_zero/endpoints/sandboxes_endpoint.rb
@@ -15,8 +15,9 @@ module ChefZero
 
         needed_checksums = FFI_Yajl::Parser.parse(request.body)["checksums"]
         result_checksums = {}
+        available_checksums = list_data(request, request.rest_path[0..1] + %w{file_store checksums})
         needed_checksums.keys.each do |needed_checksum|
-          if list_data(request, request.rest_path[0..1] + %w{file_store checksums}).include?(needed_checksum)
+          if available_checksums.include?(needed_checksum)
             result_checksums[needed_checksum] = { needs_upload: false }
           else
             result_checksums[needed_checksum] = {


### PR DESCRIPTION
## Description
This endpoint does N number of checksum checks, which can be really expensive when the N is large on the available server checksums and/or the client checksum requests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the **CONTRIBUTING** document.
- [X] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [X] All new and existing tests passed.
- [X] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
