### PR TITLE
ci: drop support for 2.7 tests on verify pipeline

### DIFF
--- a/.expeditor/verify.pipeline.yml
+++ b/.expeditor/verify.pipeline.yml
@@ -6,14 +6,6 @@ expeditor:
 
 steps:
 
-- label: run-lint-and-specs-ruby-2.7
-  command:
-    - .expeditor/run_linux_tests.sh rake spec pedant style
-  expeditor:
-    executor:
-      docker:
-        image: ruby:2.7
-
 - label: run-lint-and-specs-ruby-3.0
   command:
     - .expeditor/run_linux_tests.sh rake spec pedant style

--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/chef/chef-zero"
   s.license = "Apache-2.0"
 
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
 
   s.add_dependency "activesupport","~> 6.1"  #pin until we support ruby 2.6
   s.add_dependency "mixlib-log", ">= 2.0", "< 4.0"


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR removes tests for version 2.7 in the verify pipeline.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
