### PR TITLE
Remove unused unf_ext dependency

### DIFF
--- a/chef-zero.gemspec
+++ b/chef-zero.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   s.add_dependency "ffi-yajl", ">= 2.2", "< 4.0"
   s.add_dependency "rack", "~> 3.1", ">= 3.1.16"
   s.add_dependency "rackup", "~> 2.2", ">= 2.2.1"
-  s.add_dependency "unf_ext", "~> 0.0.8"
   s.add_dependency "webrick"
 
   s.bindir       = "bin"


### PR DESCRIPTION
## Description

The unf_ext dependency was added in PR #334 but is never actually used anywhere in the codebase - there are no require statements or usage of UNF:: classes.

This dependency causes problems for JRuby users because unf_ext is a native C extension that cannot be compiled on JRuby. Since the dependency is unused, removing it restores JRuby compatibility.

If Unicode normalization is ever needed, Ruby 3.1+ provides built-in String#unicode_normalize.

## Related Issue

Similar to PR #349 which removed unused activesupport dependency.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
